### PR TITLE
perf(merkle): optimize hashing by reusing sha256 in a pool

### DIFF
--- a/merkle/tree_test.go
+++ b/merkle/tree_test.go
@@ -121,12 +121,14 @@ func BenchmarkHashAlternatives(b *testing.B) {
 
 	b.ResetTimer()
 	b.Run("recursive", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = HashFromByteSlices(items)
 		}
 	})
 
 	b.Run("iterative", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = HashFromByteSlicesIterative(items)
 		}


### PR DESCRIPTION
This change optimizes SHA256 hashing for leafHash & innerHash by pooling and reusing hashes, which massively reduces on RAM consumption and even CPU time (benchmarking on my noisy machine is skewed but the results can be verified individually) producing results below:

```shell
$ benchstat before.txt after.txt
name                          old time/op    new time/op    delta
HashAlternatives/recursive-8    77.6µs ± 2%    77.0µs ± 2%     ~     (p=0.165 n=10+10)
HashAlternatives/iterative-8    76.3µs ± 1%    76.2µs ± 3%     ~     (p=0.720 n=9+10)

name                          old alloc/op   new alloc/op   delta
HashAlternatives/recursive-8    25.4kB ± 0%     6.4kB ± 0%  -74.94%  (p=0.000 n=10+10)
HashAlternatives/iterative-8    28.1kB ± 0%     9.1kB ± 0%  -67.78%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
HashAlternatives/recursive-8       497 ± 0%       199 ± 0%  -59.96%  (p=0.000 n=10+10)
HashAlternatives/iterative-8       498 ± 0%       200 ± 0%  -59.84%  (p=0.000 n=10+10)
```

Fixes #43

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
