### PR TITLE
fix!: use squareSizeUpperBound for worstCaseShareIndexes

### DIFF
--- a/square/builder_test.go
+++ b/square/builder_test.go
@@ -40,7 +40,7 @@ func TestBuilderSquareSizeEstimation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			txs := generateMixedTxs(tt.normalTxs, tt.pfbCount, 1, tt.pfbSize)
-			square, _, err := square.Build(txs, 64, defaultSubtreeRootThreshold)
+			square, _, err := square.Build(txs, 64, defaultSquareSizeUpperBound, defaultSubtreeRootThreshold)
 			require.NoError(t, err)
 			require.EqualValues(t, tt.expectedSquareSize, square.Size())
 		})
@@ -48,7 +48,7 @@ func TestBuilderSquareSizeEstimation(t *testing.T) {
 }
 
 func TestBuilderRejectsTransactions(t *testing.T) {
-	builder, err := square.NewBuilder(2, 64) // 2 x 2 square
+	builder, err := square.NewBuilder(2, defaultSquareSizeUpperBound, 64) // 2 x 2 square
 	require.NoError(t, err)
 	require.False(t, builder.AppendTx(newTx(shares.AvailableBytesFromCompactShares(4)+1)))
 	require.True(t, builder.AppendTx(newTx(shares.AvailableBytesFromCompactShares(4))))
@@ -81,7 +81,7 @@ func TestBuilderRejectsBlobTransactions(t *testing.T) {
 
 	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("case%d", idx), func(t *testing.T) {
-			builder, err := square.NewBuilder(2, 64)
+			builder, err := square.NewBuilder(2, defaultSquareSizeUpperBound, 64)
 			require.NoError(t, err)
 			txs := generateBlobTxsWithNamespaces(ns1.Repeat(len(tc.blobSize)), [][]int{tc.blobSize})
 			require.Len(t, txs, 1)
@@ -93,11 +93,11 @@ func TestBuilderRejectsBlobTransactions(t *testing.T) {
 }
 
 func TestBuilderInvalidConstructor(t *testing.T) {
-	_, err := square.NewBuilder(-4, 64)
+	_, err := square.NewBuilder(-4, defaultSquareSizeUpperBound, 64)
 	require.Error(t, err)
-	_, err = square.NewBuilder(0, 64)
+	_, err = square.NewBuilder(0, defaultSquareSizeUpperBound, 64)
 	require.Error(t, err)
-	_, err = square.NewBuilder(13, 64)
+	_, err = square.NewBuilder(13, defaultSquareSizeUpperBound, 64)
 	require.Error(t, err)
 }
 
@@ -109,7 +109,7 @@ func TestBuilderFindTxShareRange(t *testing.T) {
 	blockTxs := generateOrderedTxs(5, 5, 1000, 10)
 	require.Len(t, blockTxs, 10)
 
-	builder, err := square.NewBuilder(128, 64, blockTxs...)
+	builder, err := square.NewBuilder(128, defaultSquareSizeUpperBound, 64, blockTxs...)
 	require.NoError(t, err)
 
 	dataSquare, err := builder.Export()
@@ -293,7 +293,7 @@ func TestSquareBlobPostions(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
-			builder, err := square.NewBuilder(tt.squareSize, defaultSubtreeRootThreshold)
+			builder, err := square.NewBuilder(tt.squareSize, defaultSquareSizeUpperBound, defaultSubtreeRootThreshold)
 			require.NoError(t, err)
 			for _, tx := range tt.blobTxs {
 				blobTx, isBlobTx := blob.UnmarshalBlobTx(tx)

--- a/square/square.go
+++ b/square/square.go
@@ -15,8 +15,8 @@ import (
 // in the square and which have all PFBs trailing regular transactions. Note, this function does
 // not check the underlying validity of the transactions.
 // Errors should not occur and would reflect a violation in an invariant.
-func Build(txs [][]byte, maxSquareSize, subtreeRootThreshold int) (Square, [][]byte, error) {
-	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold)
+func Build(txs [][]byte, maxSquareSize, squareSizeUpperBound, subtreeRootThreshold int) (Square, [][]byte, error) {
+	builder, err := NewBuilder(maxSquareSize, squareSizeUpperBound, subtreeRootThreshold)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -44,8 +44,8 @@ func Build(txs [][]byte, maxSquareSize, subtreeRootThreshold int) (Square, [][]b
 //
 // Note that this function does not check the underlying validity of
 // the transactions.
-func Construct(txs [][]byte, maxSquareSize, subtreeRootThreshold int) (Square, error) {
-	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold, txs...)
+func Construct(txs [][]byte, maxSquareSize, squareSizeUpperBound, subtreeRootThreshold int) (Square, error) {
+	builder, err := NewBuilder(maxSquareSize, squareSizeUpperBound, subtreeRootThreshold, txs...)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +144,8 @@ func Deconstruct(s Square, decoder PFBDecoder) ([][]byte, error) {
 
 // TxShareRange returns the range of share indexes that the tx, specified by txIndex, occupies.
 // The range is end exclusive.
-func TxShareRange(txs [][]byte, txIndex, maxSquareSize, subtreeRootThreshold int) (shares.Range, error) {
-	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold, txs...)
+func TxShareRange(txs [][]byte, txIndex, maxSquareSize, squareSizeUpperBound, subtreeRootThreshold int) (shares.Range, error) {
+	builder, err := NewBuilder(maxSquareSize, squareSizeUpperBound, subtreeRootThreshold, txs...)
 	if err != nil {
 		return shares.Range{}, err
 	}
@@ -155,8 +155,8 @@ func TxShareRange(txs [][]byte, txIndex, maxSquareSize, subtreeRootThreshold int
 
 // BlobShareRange returns the range of share indexes that the blob, identified by txIndex and blobIndex, occupies.
 // The range is end exclusive.
-func BlobShareRange(txs [][]byte, txIndex, blobIndex, maxSquareSize, subtreeRootThreshold int) (shares.Range, error) {
-	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold, txs...)
+func BlobShareRange(txs [][]byte, txIndex, blobIndex, maxSquareSize, squareSizeUpperBound, subtreeRootThreshold int) (shares.Range, error) {
+	builder, err := NewBuilder(maxSquareSize, squareSizeUpperBound, subtreeRootThreshold, txs...)
 	if err != nil {
 		return shares.Range{}, err
 	}

--- a/square/square_benchmark_test.go
+++ b/square/square_benchmark_test.go
@@ -14,7 +14,7 @@ func BenchmarkSquareConstruct(b *testing.B) {
 			txs := generateOrderedTxs(txCount/2, txCount/2, 1, 1024)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := square.Construct(txs, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+				_, err := square.Construct(txs, defaultMaxSquareSize, defaultSquareSizeUpperBound, defaultSubtreeRootThreshold)
 				require.NoError(b, err)
 			}
 		})
@@ -27,7 +27,7 @@ func BenchmarkSquareBuild(b *testing.B) {
 			txs := generateMixedTxs(txCount/2, txCount/2, 1, 1024)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _, err := square.Build(txs, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+				_, _, err := square.Build(txs, defaultMaxSquareSize, defaultSquareSizeUpperBound, defaultSubtreeRootThreshold)
 				require.NoError(b, err)
 			}
 		})
@@ -38,7 +38,7 @@ func BenchmarkSquareBuild(b *testing.B) {
 			txs := generateMixedTxs(0, txCount, 1, blobSize)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _, err := square.Build(txs, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+				_, _, err := square.Build(txs, defaultMaxSquareSize, defaultSquareSizeUpperBound, defaultSubtreeRootThreshold)
 				require.NoError(b, err)
 			}
 		})


### PR DESCRIPTION
Closes https://github.com/celestiaorg/go-square/issues/47

This restores the behavior from celestia-app v1.x where square size upper bound is used to calculate worstCaseShareIndexes. 

## Testing

In celestia-app, TestMaxBlockSize flake is no longer observed

```
 go test -run TestIntegrationTestSuite/TestMaxBlockSize -count 5 -v
```