### PR TITLE
perf(namespace): speed up Namespace comparisons

### DIFF
--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -119,23 +119,23 @@ func (n Namespace) IsSecondaryReserved() bool {
 }
 
 func (n Namespace) IsParityShares() bool {
-	return bytes.Equal(n.Bytes(), ParitySharesNamespace.Bytes())
+	return n.Equals(ParitySharesNamespace)
 }
 
 func (n Namespace) IsTailPadding() bool {
-	return bytes.Equal(n.Bytes(), TailPaddingNamespace.Bytes())
+	return n.Equals(TailPaddingNamespace)
 }
 
 func (n Namespace) IsPrimaryReservedPadding() bool {
-	return bytes.Equal(n.Bytes(), PrimaryReservedPaddingNamespace.Bytes())
+	return n.Equals(PrimaryReservedPaddingNamespace)
 }
 
 func (n Namespace) IsTx() bool {
-	return bytes.Equal(n.Bytes(), TxNamespace.Bytes())
+	return n.Equals(TxNamespace)
 }
 
 func (n Namespace) IsPayForBlob() bool {
-	return bytes.Equal(n.Bytes(), PayForBlobNamespace.Bytes())
+	return n.Equals(PayForBlobNamespace)
 }
 
 func (n Namespace) Repeat(times int) []Namespace {
@@ -147,23 +147,34 @@ func (n Namespace) Repeat(times int) []Namespace {
 }
 
 func (n Namespace) Equals(n2 Namespace) bool {
-	return bytes.Equal(n.Bytes(), n2.Bytes())
+	return n.Version == n2.Version && bytes.Equal(n.ID, n2.ID)
 }
 
 func (n Namespace) IsLessThan(n2 Namespace) bool {
-	return bytes.Compare(n.Bytes(), n2.Bytes()) == -1
+	return n.Compare(n2) == -1
 }
 
 func (n Namespace) IsLessOrEqualThan(n2 Namespace) bool {
-	return bytes.Compare(n.Bytes(), n2.Bytes()) < 1
+	return n.Compare(n2) < 1
 }
 
 func (n Namespace) IsGreaterThan(n2 Namespace) bool {
-	return bytes.Compare(n.Bytes(), n2.Bytes()) == 1
+	return n.Compare(n2) == 1
 }
 
 func (n Namespace) IsGreaterOrEqualThan(n2 Namespace) bool {
-	return bytes.Compare(n.Bytes(), n2.Bytes()) > -1
+	return n.Compare(n2) > -1
+}
+
+func (n Namespace) Compare(n2 Namespace) int {
+	switch {
+	case n.Version == n2.Version:
+		return bytes.Compare(n.ID, n2.ID)
+	case n.Version < n2.Version:
+		return -1
+	default:
+		return 1
+	}
 }
 
 // leftPad returns a new byte slice with the provided byte slice left-padded to the provided size.

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -297,3 +297,39 @@ func TestIsReserved(t *testing.T) {
 		assert.Equal(t, tc.want, got)
 	}
 }
+
+func BenchmarkEqual(b *testing.B) {
+	n1 := RandomNamespace()
+	n2 := RandomNamespace()
+	// repeat until n2 meets our expectations.
+	for n1.Equals(n2) {
+		n2 = RandomNamespace()
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if n1.Equals(n2) {
+			b.Fatal()
+		}
+	}
+}
+
+func BenchmarkCompare(b *testing.B) {
+	n1 := RandomNamespace()
+	n2 := RandomNamespace()
+	// repeat until n2 meets our expectations.
+	for n1.Compare(n2) != 1 {
+		n2 = RandomNamespace()
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if n1.Compare(n2) != 1 {
+			b.Fatal()
+		}
+	}
+}


### PR DESCRIPTION
## Overview

While reading and checking structures from https://celestiaorg.github.io/celestia-app/specs/data_structures.html I noticed that we compare namespaces not optimal enough. Every equal or compare-like operation allocates new slice with data that can be already compared directly. 

```
% go-perftuner bstat a.txt b.txt
args: [a.txt b.txt]name        old time/op    new time/op    delta
Equal-10      71.9ns ± 0%     3.9ns ± 0%   -94.53%  (p=0.008 n=5+5)
Compare-10    72.0ns ± 1%     4.4ns ± 5%   -93.83%  (p=0.002 n=6+6)

name        old alloc/op   new alloc/op   delta
Equal-10       64.0B ± 0%      0.0B       -100.00%  (p=0.026 n=5+6)
Compare-10     64.0B ± 0%      0.0B       -100.00%  (p=0.002 n=6+6)

name        old allocs/op  new allocs/op  delta
Equal-10        2.00 ± 0%      0.00       -100.00%  (p=0.026 n=5+6)
Compare-10      2.00 ± 0%      0.00       -100.00%  (p=0.002 n=6+6)
```