### PR TITLE
ci: utilize go version from go.mod

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - "v[0-9]+.x"
+      - ci/ramin/go-version
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
       - "v[0-9]+.x"
-      - ci/ramin/go-version
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: lint
 on:
   workflow_call:
 
-env:
-  GO_VERSION: '1.21.1'
-
 jobs:
   golangci-lint:
     name: golangci-lint
@@ -12,9 +9,11 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ./go.mod
+
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           # This job will pass without running if go.mod, go.sum, and *.go
@@ -23,6 +22,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
+
       - uses: golangci/golangci-lint-action@v6.0.1
         with:
           version: v1.55.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: test
 on:
   workflow_call:
 
-env:
-  GO_VERSION: '1.21.1'
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,7 +10,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: ./go.mod
 
       - name: Run tests
         run: go test ./... -v -timeout 5m -race


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

drive by! was glancing at the namespace PR and saw we could remove the hardcoded `GO_VERSION` ENV var for loading directly from the go.mod, figured i'd do my part 🫡 