### PR TITLE
chore: expose generate subtree roots method

### DIFF
--- a/inclusion/commitment.go
+++ b/inclusion/commitment.go
@@ -15,6 +15,19 @@ type MerkleRootFn func([][]byte) []byte
 // [data square layout rationale]: ../../specs/src/specs/data_square_layout.md
 // [blob share commitment rules]: ../../specs/src/specs/data_square_layout.md#blob-share-commitment-rules
 func CreateCommitment(blob *sh.Blob, merkleRootFn MerkleRootFn, subtreeRootThreshold int) ([]byte, error) {
+	subTreeRoots, err := GenerateSubtreeRoots(blob, subtreeRootThreshold)
+	if err != nil {
+		return nil, err
+	}
+	return merkleRootFn(subTreeRoots), nil
+}
+
+// GenerateSubtreeRoots generates the subtree roots of a blob.
+// See [data square layout rationale] and [blob share commitment rules].
+//
+// [data square layout rationale]: ../../specs/src/specs/data_square_layout.md
+// [blob share commitment rules]: ../../specs/src/specs/data_square_layout.md#blob-share-commitment-rules
+func GenerateSubtreeRoots(blob *sh.Blob, subtreeRootThreshold int) ([][]byte, error) {
 	shares, err := splitBlobs(blob)
 	if err != nil {
 		return nil, err
@@ -65,7 +78,7 @@ func CreateCommitment(blob *sh.Blob, merkleRootFn MerkleRootFn, subtreeRootThres
 		}
 		subTreeRoots[i] = root
 	}
-	return merkleRootFn(subTreeRoots), nil
+	return subTreeRoots, nil
 }
 
 func CreateCommitments(blobs []*sh.Blob, merkleRootFn MerkleRootFn, subtreeRootThreshold int) ([][]byte, error) {


### PR DESCRIPTION
This PR exposes a method to generate the subtree roots. It will be handy in downstream repos (will be using it in Celestia-node) instead of re-implementing it.

Will be cherry picking this change to v1.x to be able to use it now