### PR TITLE
chore: add fmt target to makefile and fix linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ lint:
 	@golangci-lint run
 .PHONY: lint
 
+## fmt: Format files per linters golangci-lint and markdownlint.
+fmt:
+	@echo "--> Running golangci-lint --fix"
+	@golangci-lint run --fix
+	@echo "--> Running markdownlint --fix"
+	@markdownlint --fix --quiet --config .markdownlint.yaml .
+.PHONY: fmt
+
 ## test: Run unit tests.
 test:
 	@echo "--> Run unit tests"

--- a/share/share_builder_test.go
+++ b/share/share_builder_test.go
@@ -2,7 +2,6 @@ package share
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -298,7 +297,7 @@ func TestShareBuilderImportRawData(t *testing.T) {
 			rawData := builtShare.RawData()
 			// Since rawData has padding, we need to use contains
 			if !bytes.Contains(rawData, tc.want) {
-				t.Errorf(fmt.Sprintf("%#v does not contain %#v", rawData, tc.want))
+				t.Errorf("%#v does not contain %#v", rawData, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Just adds the `fmt` target to Makefile and fixes a linting issue (that it's not showing now because linter version in here is old but once we bump to latest, will show)