### PR TITLE
refactor: shares needed

### DIFF
--- a/share/share_sequence.go
+++ b/share/share_sequence.go
@@ -109,11 +109,16 @@ func SparseSharesNeeded(sequenceLen uint32) (sharesNeeded int) {
 		return 1
 	}
 
-	bytesAvailable := FirstSparseShareContentSize
-	sharesNeeded++
-	for uint32(bytesAvailable) < sequenceLen {
-		bytesAvailable += ContinuationSparseShareContentSize
-		sharesNeeded++
+	// Calculate remaining bytes after first share
+	remainingBytes := sequenceLen - FirstSparseShareContentSize
+
+	// Calculate number of continuation shares needed
+	continuationShares := remainingBytes / ContinuationSparseShareContentSize
+	isOverflowLastShare := remainingBytes % ContinuationSparseShareContentSize
+	if isOverflowLastShare > 0 {
+		continuationShares++
 	}
-	return sharesNeeded
+
+	// 1 sparse share + continuation shares
+	return 1 + int(continuationShares)
 }

--- a/share/share_sequence.go
+++ b/share/share_sequence.go
@@ -89,13 +89,18 @@ func CompactSharesNeeded(sequenceLen uint32) (sharesNeeded int) {
 		return 1
 	}
 
-	bytesAvailable := uint32(FirstCompactShareContentSize)
-	sharesNeeded++
-	for bytesAvailable < sequenceLen {
-		bytesAvailable += ContinuationCompactShareContentSize
-		sharesNeeded++
+	// Calculate remaining bytes after first share
+	remainingBytes := sequenceLen - FirstCompactShareContentSize
+
+	// Calculate number of continuation shares needed
+	continuationShares := remainingBytes / ContinuationCompactShareContentSize
+	isOverflowLastShare := remainingBytes % ContinuationCompactShareContentSize
+	if isOverflowLastShare > 0 {
+		continuationShares++
 	}
-	return sharesNeeded
+
+	// 1 first share + continuation shares
+	return 1 + int(continuationShares)
 }
 
 // SparseSharesNeeded returns the number of shares needed to store a sequence of
@@ -119,6 +124,6 @@ func SparseSharesNeeded(sequenceLen uint32) (sharesNeeded int) {
 		continuationShares++
 	}
 
-	// 1 sparse share + continuation shares
+	// 1 first share + continuation shares
 	return 1 + int(continuationShares)
 }

--- a/share/share_sequence.go
+++ b/share/share_sequence.go
@@ -94,8 +94,8 @@ func CompactSharesNeeded(sequenceLen uint32) (sharesNeeded int) {
 
 	// Calculate number of continuation shares needed
 	continuationShares := remainingBytes / ContinuationCompactShareContentSize
-	isOverflowLastShare := remainingBytes % ContinuationCompactShareContentSize
-	if isOverflowLastShare > 0 {
+	overflow := remainingBytes % ContinuationCompactShareContentSize
+	if overflow > 0 {
 		continuationShares++
 	}
 
@@ -119,8 +119,8 @@ func SparseSharesNeeded(sequenceLen uint32) (sharesNeeded int) {
 
 	// Calculate number of continuation shares needed
 	continuationShares := remainingBytes / ContinuationSparseShareContentSize
-	isOverflowLastShare := remainingBytes % ContinuationSparseShareContentSize
-	if isOverflowLastShare > 0 {
+	overflow := remainingBytes % ContinuationSparseShareContentSize
+	if overflow > 0 {
 		continuationShares++
 	}
 

--- a/share/share_sequence_test.go
+++ b/share/share_sequence_test.go
@@ -93,6 +93,8 @@ func TestCompactSharesNeeded(t *testing.T) {
 		{1000, 3},
 		{10000, 21},
 		{100000, 210},
+		{math.MaxUint32 - ShareSize, 8985287},
+		{math.MaxUint32, 8985288},
 	}
 	for _, tc := range testCases {
 		got := CompactSharesNeeded(tc.sequenceLen)

--- a/share/share_sequence_test.go
+++ b/share/share_sequence_test.go
@@ -90,6 +90,9 @@ func TestCompactSharesNeeded(t *testing.T) {
 		{FirstCompactShareContentSize + 1, 2},
 		{FirstCompactShareContentSize + ContinuationCompactShareContentSize, 2},
 		{FirstCompactShareContentSize + ContinuationCompactShareContentSize*100, 101},
+		{1000, 3},
+		{10000, 21},
+		{100000, 210},
 	}
 	for _, tc := range testCases {
 		got := CompactSharesNeeded(tc.sequenceLen)

--- a/share/share_sequence_test.go
+++ b/share/share_sequence_test.go
@@ -3,6 +3,7 @@ package share
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,6 +114,8 @@ func TestSparseSharesNeeded(t *testing.T) {
 		{1000, 3},
 		{10000, 21},
 		{100000, 208},
+		{math.MaxUint32 - ShareSize, 8910720},
+		{math.MaxUint32, 8910721},
 	}
 	for _, tc := range testCases {
 		got := SparseSharesNeeded(tc.sequenceLen)


### PR DESCRIPTION
`SparseSharesNeeded` is slow when invoked with large sequence lengths. This refactors `SparseSharesNeeded` so that it can compute the number of shares needed much faster.

I noticed `CompactSharesNeeded` could use the same refactor so bundled with this change.