### PR TITLE
revert: "chore(deps): bump golangci/golangci-lint-action from 6.3.2 to 7.0.0"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
             go.mod
             go.sum
 
-      - uses: golangci/golangci-lint-action@v7.0.0
+      - uses: golangci/golangci-lint-action@v6.3.2
         with:
           version: v1.63.4
           args: --timeout 10m


### PR DESCRIPTION
Reverts celestiaorg/go-square#140 because the action had a breaking change which wasn't previously called out. It now requires golangci-lint v2 which wasn't included in that PR.