### PR TITLE
chore: `validate` namespace via `ValidateForData` and `ValidateForBlob`

### DIFF
--- a/share/namespace.go
+++ b/share/namespace.go
@@ -150,9 +150,6 @@ func (n Namespace) ValidateForData() error {
 // an error is returned indicating the issue. This ensures that only valid namespaces are
 // used when dealing with blob data.
 func (n Namespace) ValidateForBlob() error {
-	if err := n.validate(); err != nil {
-		return err
-	}
 	if err := n.ValidateForData(); err != nil {
 		return err
 	}

--- a/share/namespace.go
+++ b/share/namespace.go
@@ -135,6 +135,9 @@ func (n Namespace) validate() error {
 
 // ValidateForData checks if the Namespace is of real/useful data.
 func (n Namespace) ValidateForData() error {
+	if err := n.validate(); err != nil {
+		return err
+	}
 	if !n.IsUsableNamespace() {
 		return fmt.Errorf("invalid data namespace(%s): parity and tail padding namespace are forbidden", n)
 	}
@@ -147,6 +150,9 @@ func (n Namespace) ValidateForData() error {
 // an error is returned indicating the issue. This ensures that only valid namespaces are
 // used when dealing with blob data.
 func (n Namespace) ValidateForBlob() error {
+	if err := n.validate(); err != nil {
+		return err
+	}
 	if err := n.ValidateForData(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Context 

In a conversation with @renaynay , we noticed that `ValidateForBlob` and `ValidateForData` don't currently `validate` the namespace. This isn't a problem in practice because [NewNamespace](https://github.com/rootulp/go-square/blob/bb54ed5e3395f20e6e14e49ddf96942cdcac5e70/share/namespace.go#L41-L43) performs this validation so it's only an issue if a namespace is constructed without using the constructor:

```go
func demo() {
	// Create a namespace without using the constructor
	invalid := Namespace{
		data: []byte{0x01, 0xFF}
	}
	invalid.ValidateForData() // this should error but currently doesn't
}
```

This PR fixes that oversight and adds unit tests.