### PR TITLE
fix: stop appending txs in `Build` after first one can not fit

### DIFF
--- a/square.go
+++ b/square.go
@@ -40,7 +40,10 @@ func Build(txs [][]byte, maxSquareSize, subtreeRootThreshold int) (Square, [][]b
 		}
 	}
 	square, err := builder.Export()
-	return square, append(normalTxs, blobTxs...), err
+	if err != nil {
+		return nil, nil, err
+	}
+	return square, append(normalTxs, blobTxs...), nil
 }
 
 // Construct takes the exact list of ordered transactions and constructs a square, validating that

--- a/square.go
+++ b/square.go
@@ -32,10 +32,16 @@ func Build(txs [][]byte, maxSquareSize, subtreeRootThreshold int) (Square, [][]b
 		if isBlobTx {
 			if builder.AppendBlobTx(blobTx) {
 				blobTxs = append(blobTxs, txBytes)
+			} else {
+				// The blobTx can not fit so exit the txs loop and return the square.
+				break
 			}
 		} else {
 			if builder.AppendTx(txBytes) {
 				normalTxs = append(normalTxs, txBytes)
+			} else {
+				// The normal tx can not fit so exit the txs loop and return the square.
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/4961
Part of https://github.com/celestiaorg/celestia-app/issues/4981
Unblocks https://github.com/celestiaorg/celestia-app/pull/4976

Pros
- This isn't consensus breaking because `square.Build` is only invoked in `PrepareProposal`.
- Stops proposers from generating a proposal that includes txs with out of order sequences. In other words, prevents the `account sequence mismatch` error we were hitting in ProcessProposal.

Cons
- Lowers the efficiency of squares. Previously square.Build was greedy and tried to pack as many txs as possible into a square. Now it stops as soon as the first tx can not fit. This means worse case that squares are 6 MiB full because the max tx size is 2 MiB and the max square size is 8 MiB.