### PR TITLE
preventing potential division-by-zero runtime panics in RoundUpByMult…

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -211,10 +211,15 @@ func (b *Builder) Export() (Square, error) {
 	for i, element := range b.Blobs {
 		// NextShareIndex returned where the next blob should start so as to comply with the share commitment rules
 		// We fill out the remaining
-		cursor = inclusion.NextShareIndex(cursor, element.NumShares, b.subtreeRootThreshold)
+		nextCursor, err := inclusion.NextShareIndex(cursor, element.NumShares, b.subtreeRootThreshold)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate next share index for blob %d: %w", i, err)
+		}
 		if i == 0 {
 			nonReservedStart = cursor
 		}
+
+		cursor = nextCursor
 
 		// defensively check that the actual padding never exceeds the max padding initially allocated for it
 		padding := cursor - endOfLastBlob


### PR DESCRIPTION
RoundUpByMultipleOf: check for zero denominator and return error

Preventing potential division-by-zero runtime panics in RoundUpByMultipleOf by explicitly checking if the denominator (v) is zero. If v is zero, the function returns an error instead of proceeding with the calculation.

This change is API-breaking as the function signature now returns
(int, error) instead of just int.

Fixes #45 
