### PR TITLE
fix: ony the first share should parse the signer

### DIFF
--- a/share/parse_sparse_shares.go
+++ b/share/parse_sparse_shares.go
@@ -44,12 +44,19 @@ func parseSparseShares(shares []Share) (blobs []*Blob, err error) {
 			if len(sequences) == 0 {
 				return nil, fmt.Errorf("continuation share %v without a sequence start share", share)
 			}
-			// FIXME: it doesn't look like we check whether all the shares belong to the same namespace.
+			if !share.Namespace().Equals(sequences[len(sequences)-1].ns) {
+				return nil, fmt.Errorf("continuation share %v has a different namespace than the previous share %v",
+					share.Namespace(), sequences[len(sequences)-1].ns)
+			}
 			prev := &sequences[len(sequences)-1]
 			prev.data = append(prev.data, share.RawData()...)
 		}
 	}
 	for _, sequence := range sequences {
+		if sequence.sequenceLen > uint32(len(sequence.data)) {
+			return nil, fmt.Errorf("sequence length %v is greater than the number of bytes in the sequence %v",
+				sequence.sequenceLen, len(sequence.data))
+		}
 		// trim any padding from the end of the sequence
 		sequence.data = sequence.data[:sequence.sequenceLen]
 		blob, err := NewBlob(sequence.ns, sequence.data, sequence.shareVersion, sequence.signer)

--- a/share/share.go
+++ b/share/share.go
@@ -162,7 +162,8 @@ func (s *Share) rawDataStartIndex() int {
 	if isCompact {
 		index += ShareReservedBytes
 	}
-	if s.Version() == ShareVersionOne {
+	if s.Version() == ShareVersionOne && s.IsSequenceStart() {
+		// the first share in v1 has the signer
 		index += SignerSize
 	}
 	return index


### PR DESCRIPTION
The parser would parse the shares assuming that every share included the signer rather than just the first share. This meant that data would be missing when converted into a blob