### PR TITLE
chore: prep for v3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-square
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/celestiaorg/go-square/v2.svg)](https://pkg.go.dev/github.com/celestiaorg/go-square/v2)
+[![Go Reference](https://pkg.go.dev/badge/github.com/celestiaorg/go-square/v3.svg)](https://pkg.go.dev/github.com/celestiaorg/go-square/v3)
 
 `go-square` is a Go module that provides data structures and utilities for interacting with data squares in the Celestia network. The data square is a special form of block serialization in the Celestia blockchain designed for sampling. This repo deals with the original data square which is distinct from the extended data square. Operations on the extended data square are handled by [rsmt2d](https://github.com/celestiaorg/rsmt2d).
 
@@ -17,12 +17,12 @@ tx        | Package tx contains BlobTx and IndexWrapper types
 To use `go-square` as a dependency in your Go project, you can use `go get`:
 
 ```bash
-go get github.com/celestiaorg/go-square/v2
+go get github.com/celestiaorg/go-square/v3
 ```
 
 ## Branches and Releasing
 
-This repo has one long living development branch `main`, for changes targeting the next major version as well as long living branches for each prior major version i.e. `v1.x`. Non breaking changes may be backported to these branches. This repo follows [semver](https://www.semver.org) versioning.
+This repo has one long living development branch `main`, for changes targeting the next major version as well as long living branches for each prior major version i.e. `v1.x`, `v2.x`. Non breaking changes may be backported to these branches. This repo follows [semver](https://www.semver.org) versioning.
 
 ## Contributing
 

--- a/builder.go
+++ b/builder.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/celestiaorg/go-square/v2/inclusion"
-	v1 "github.com/celestiaorg/go-square/v2/proto/blob/v1"
-	"github.com/celestiaorg/go-square/v2/share"
-	"github.com/celestiaorg/go-square/v2/tx"
+	"github.com/celestiaorg/go-square/v3/inclusion"
+	v1 "github.com/celestiaorg/go-square/v3/proto/blob/v1"
+	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v3/tx"
 	"golang.org/x/exp/constraints"
 	"google.golang.org/protobuf/proto"
 )

--- a/builder_test.go
+++ b/builder_test.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2"
-	"github.com/celestiaorg/go-square/v2/internal/test"
-	"github.com/celestiaorg/go-square/v2/share"
-	"github.com/celestiaorg/go-square/v2/tx"
+	"github.com/celestiaorg/go-square/v3"
+	"github.com/celestiaorg/go-square/v3/internal/test"
+	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v3/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/celestiaorg/go-square/v2
+module github.com/celestiaorg/go-square/v3
 
 go 1.23.6
 

--- a/inclusion/blob_share_commitment_rules_test.go
+++ b/inclusion/blob_share_commitment_rules_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2/inclusion"
+	"github.com/celestiaorg/go-square/v3/inclusion"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/inclusion/commitment.go
+++ b/inclusion/commitment.go
@@ -3,7 +3,7 @@ package inclusion
 import (
 	"crypto/sha256"
 
-	sh "github.com/celestiaorg/go-square/v2/share"
+	sh "github.com/celestiaorg/go-square/v3/share"
 	"github.com/celestiaorg/nmt"
 )
 

--- a/inclusion/commitment_test.go
+++ b/inclusion/commitment_test.go
@@ -5,8 +5,8 @@ import (
 	"crypto/sha256"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2/inclusion"
-	"github.com/celestiaorg/go-square/v2/share"
+	"github.com/celestiaorg/go-square/v3/inclusion"
+	"github.com/celestiaorg/go-square/v3/share"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/test/factory.go
+++ b/internal/test/factory.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/celestiaorg/go-square/v2/share"
-	"github.com/celestiaorg/go-square/v2/tx"
+	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v3/tx"
 )
 
 var DefaultTestNamespace = share.MustNewV0Namespace([]byte("test"))

--- a/internal/test/factory_test.go
+++ b/internal/test/factory_test.go
@@ -3,7 +3,7 @@ package test_test
 import (
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2/internal/test"
+	"github.com/celestiaorg/go-square/v3/internal/test"
 	"github.com/stretchr/testify/require"
 )
 

--- a/proto/blob/v1/blob.proto
+++ b/proto/blob/v1/blob.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package proto.blob.v1;
 
-option go_package = "github.com/celestiaorg/go-square/v2/proto/blob/v1";
+option go_package = "github.com/celestiaorg/go-square/v3/proto/blob/v1";
 
 // BlobProto is the protobuf representation of a blob (binary large object)
 // to be published to the Celestia blockchain. The data of a Blob is published

--- a/share/blob.go
+++ b/share/blob.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sort"
 
-	v1 "github.com/celestiaorg/go-square/v2/proto/blob/v1"
+	v1 "github.com/celestiaorg/go-square/v3/proto/blob/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/share/blob_test.go
+++ b/share/blob_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	v1 "github.com/celestiaorg/go-square/v2/proto/blob/v1"
+	v1 "github.com/celestiaorg/go-square/v3/proto/blob/v1"
 	"github.com/stretchr/testify/require"
 )
 

--- a/share/counter_test.go
+++ b/share/counter_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2/share"
+	"github.com/celestiaorg/go-square/v3/share"
 	"github.com/stretchr/testify/require"
 )
 

--- a/share/range_test.go
+++ b/share/range_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/go-square/v2/internal/test"
-	"github.com/celestiaorg/go-square/v2/share"
+	"github.com/celestiaorg/go-square/v3/internal/test"
+	"github.com/celestiaorg/go-square/v3/share"
 )
 
 func TestGetShareRangeForNamespace(t *testing.T) {

--- a/share/share_benchmark_test.go
+++ b/share/share_benchmark_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2/internal/test"
-	"github.com/celestiaorg/go-square/v2/share"
+	"github.com/celestiaorg/go-square/v3/internal/test"
+	"github.com/celestiaorg/go-square/v3/share"
 )
 
 func BenchmarkBlobsToShares(b *testing.B) {

--- a/square.go
+++ b/square.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/celestiaorg/go-square/v2/share"
-	"github.com/celestiaorg/go-square/v2/tx"
+	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v3/tx"
 	"golang.org/x/exp/constraints"
 )
 

--- a/square_benchmark_test.go
+++ b/square_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2"
+	"github.com/celestiaorg/go-square/v3"
 	"github.com/stretchr/testify/require"
 )
 

--- a/square_test.go
+++ b/square_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v2"
-	"github.com/celestiaorg/go-square/v2/internal/test"
-	"github.com/celestiaorg/go-square/v2/share"
-	"github.com/celestiaorg/go-square/v2/tx"
+	"github.com/celestiaorg/go-square/v3"
+	"github.com/celestiaorg/go-square/v3/internal/test"
+	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v3/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tx/blob_tx.go
+++ b/tx/blob_tx.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "github.com/celestiaorg/go-square/v2/proto/blob/v1"
-	"github.com/celestiaorg/go-square/v2/share"
+	v1 "github.com/celestiaorg/go-square/v3/proto/blob/v1"
+	"github.com/celestiaorg/go-square/v3/share"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/tx/index_wrapper.go
+++ b/tx/index_wrapper.go
@@ -3,7 +3,7 @@ package tx
 import (
 	"google.golang.org/protobuf/proto"
 
-	"github.com/celestiaorg/go-square/v2/proto/blob/v1"
+	v1 "github.com/celestiaorg/go-square/v3/proto/blob/v1"
 )
 
 const (


### PR DESCRIPTION
Prepare for creating the v3.0.0 release by changing the go `module` declaration to have a `/v3` suffix