### PR TITLE
chore: prep for v4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-square
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/celestiaorg/go-square/v3.svg)](https://pkg.go.dev/github.com/celestiaorg/go-square/v3)
+[![Go Reference](https://pkg.go.dev/badge/github.com/celestiaorg/go-square/v4.svg)](https://pkg.go.dev/github.com/celestiaorg/go-square/v4)
 
 `go-square` is a Go module that provides data structures and utilities for interacting with data squares in the Celestia network. The data square is a special form of block serialization in the Celestia blockchain designed for sampling. This repo deals with the original data square which is distinct from the extended data square. Operations on the extended data square are handled by [rsmt2d](https://github.com/celestiaorg/rsmt2d).
 
@@ -17,7 +17,7 @@ tx        | Package tx contains BlobTx and IndexWrapper types
 To use `go-square` as a dependency in your Go project, you can use `go get`:
 
 ```bash
-go get github.com/celestiaorg/go-square/v3
+go get github.com/celestiaorg/go-square/v4
 ```
 
 ## Branches and Releasing

--- a/builder.go
+++ b/builder.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/celestiaorg/go-square/v3/inclusion"
-	v2 "github.com/celestiaorg/go-square/v3/proto/blob/v2"
-	"github.com/celestiaorg/go-square/v3/share"
-	"github.com/celestiaorg/go-square/v3/tx"
+	"github.com/celestiaorg/go-square/v4/inclusion"
+	v2 "github.com/celestiaorg/go-square/v4/proto/blob/v2"
+	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/celestiaorg/go-square/v4/tx"
 	"golang.org/x/exp/constraints"
 	"google.golang.org/protobuf/proto"
 )

--- a/builder_test.go
+++ b/builder_test.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v3"
-	"github.com/celestiaorg/go-square/v3/internal/test"
-	"github.com/celestiaorg/go-square/v3/share"
-	"github.com/celestiaorg/go-square/v3/tx"
+	"github.com/celestiaorg/go-square/v4"
+	"github.com/celestiaorg/go-square/v4/internal/test"
+	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/celestiaorg/go-square/v4/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/celestiaorg/go-square/v3
+module github.com/celestiaorg/go-square/v4
 
 go 1.24.0
 

--- a/inclusion/blob_share_commitment_rules_test.go
+++ b/inclusion/blob_share_commitment_rules_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v3/inclusion"
+	"github.com/celestiaorg/go-square/v4/inclusion"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/inclusion/commitment.go
+++ b/inclusion/commitment.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	sh "github.com/celestiaorg/go-square/v3/share"
+	sh "github.com/celestiaorg/go-square/v4/share"
 	"github.com/celestiaorg/nmt"
 	"golang.org/x/sync/errgroup"
 )

--- a/inclusion/commitment_test.go
+++ b/inclusion/commitment_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/celestiaorg/go-square/v3/inclusion"
-	"github.com/celestiaorg/go-square/v3/internal/test"
-	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v4/inclusion"
+	"github.com/celestiaorg/go-square/v4/internal/test"
+	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/inclusion/nmt_pool.go
+++ b/inclusion/nmt_pool.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"errors"
 
-	sh "github.com/celestiaorg/go-square/v3/share"
+	sh "github.com/celestiaorg/go-square/v4/share"
 	"github.com/celestiaorg/nmt"
 )
 

--- a/internal/test/factory.go
+++ b/internal/test/factory.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/celestiaorg/go-square/v3/share"
-	"github.com/celestiaorg/go-square/v3/tx"
+	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/celestiaorg/go-square/v4/tx"
 )
 
 var DefaultTestNamespace = share.MustNewV0Namespace([]byte("test"))

--- a/internal/test/factory_test.go
+++ b/internal/test/factory_test.go
@@ -3,7 +3,7 @@ package test_test
 import (
 	"testing"
 
-	"github.com/celestiaorg/go-square/v3/internal/test"
+	"github.com/celestiaorg/go-square/v4/internal/test"
 	"github.com/stretchr/testify/require"
 )
 

--- a/proto/blob/v2/blob.pb.go
+++ b/proto/blob/v2/blob.pb.go
@@ -7,11 +7,12 @@
 package v2
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -246,7 +247,7 @@ const file_proto_blob_v2_blob_proto_rawDesc = "" +
 	"\fIndexWrapper\x12\x0e\n" +
 	"\x02tx\x18\x01 \x01(\fR\x02tx\x12#\n" +
 	"\rshare_indexes\x18\x02 \x03(\rR\fshareIndexes\x12\x17\n" +
-	"\atype_id\x18\x03 \x01(\tR\x06typeIdB3Z1github.com/celestiaorg/go-square/v3/proto/blob/v2b\x06proto3"
+	"\atype_id\x18\x03 \x01(\tR\x06typeIdB3Z1github.com/celestiaorg/go-square/v4/proto/blob/v2b\x06proto3"
 
 var (
 	file_proto_blob_v2_blob_proto_rawDescOnce sync.Once

--- a/proto/blob/v2/blob.proto
+++ b/proto/blob/v2/blob.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package proto.blob.v2;
 
-option go_package = "github.com/celestiaorg/go-square/v3/proto/blob/v2";
+option go_package = "github.com/celestiaorg/go-square/v4/proto/blob/v2";
 
 // BlobProto is the protobuf representation of a blob (binary large object)
 // to be published to the Celestia blockchain. The data of a Blob is published

--- a/share/blob.go
+++ b/share/blob.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sort"
 
-	v2 "github.com/celestiaorg/go-square/v3/proto/blob/v2"
+	v2 "github.com/celestiaorg/go-square/v4/proto/blob/v2"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/share/blob_test.go
+++ b/share/blob_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	v2 "github.com/celestiaorg/go-square/v3/proto/blob/v2"
+	v2 "github.com/celestiaorg/go-square/v4/proto/blob/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/share/counter_test.go
+++ b/share/counter_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/stretchr/testify/require"
 )
 

--- a/share/range_test.go
+++ b/share/range_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/go-square/v3/internal/test"
-	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v4/internal/test"
+	"github.com/celestiaorg/go-square/v4/share"
 )
 
 func TestGetShareRangeForNamespace(t *testing.T) {

--- a/share/share_benchmark_test.go
+++ b/share/share_benchmark_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v3/internal/test"
-	"github.com/celestiaorg/go-square/v3/share"
+	"github.com/celestiaorg/go-square/v4/internal/test"
+	"github.com/celestiaorg/go-square/v4/share"
 )
 
 func BenchmarkBlobsToShares(b *testing.B) {

--- a/square.go
+++ b/square.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/celestiaorg/go-square/v3/share"
-	"github.com/celestiaorg/go-square/v3/tx"
+	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/celestiaorg/go-square/v4/tx"
 	"golang.org/x/exp/constraints"
 )
 

--- a/square_benchmark_test.go
+++ b/square_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v3"
+	"github.com/celestiaorg/go-square/v4"
 	"github.com/stretchr/testify/require"
 )
 

--- a/square_test.go
+++ b/square_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/celestiaorg/go-square/v3"
-	"github.com/celestiaorg/go-square/v3/internal/test"
-	"github.com/celestiaorg/go-square/v3/share"
-	"github.com/celestiaorg/go-square/v3/tx"
+	"github.com/celestiaorg/go-square/v4"
+	"github.com/celestiaorg/go-square/v4/internal/test"
+	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/celestiaorg/go-square/v4/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tx/blob_tx.go
+++ b/tx/blob_tx.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	v2 "github.com/celestiaorg/go-square/v3/proto/blob/v2"
-	"github.com/celestiaorg/go-square/v3/share"
+	v2 "github.com/celestiaorg/go-square/v4/proto/blob/v2"
+	"github.com/celestiaorg/go-square/v4/share"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/tx/index_wrapper.go
+++ b/tx/index_wrapper.go
@@ -3,7 +3,7 @@ package tx
 import (
 	"google.golang.org/protobuf/proto"
 
-	v2 "github.com/celestiaorg/go-square/v3/proto/blob/v2"
+	v2 "github.com/celestiaorg/go-square/v4/proto/blob/v2"
 )
 
 const (


### PR DESCRIPTION
Bump the go module to v4 so that we can use an RC created from the feature/fibre branch.