### PR TITLE
feat: add ShareVersionTwo blob and share support (3/5)

### DIFF
--- a/share/blob_test.go
+++ b/share/blob_test.go
@@ -3,10 +3,12 @@ package share
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"testing"
 
 	v4 "github.com/celestiaorg/go-square/v4/proto/blob/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,9 +70,13 @@ func TestBlobConstructor(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "share version 128 not supported")
 
-	_, err = NewBlob(ns, data, 2, nil)
+	_, err = NewBlob(ns, data, 2, signer)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "share version 2 not supported")
+	require.Contains(t, err.Error(), "share version 2 requires data of size")
+
+	_, err = NewBlob(ns, data, 3, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "share version 3 not supported")
 
 	_, err = NewBlob(Namespace{}, data, 1, signer)
 	require.Error(t, err)
@@ -161,6 +167,39 @@ func TestNewBlobFromProto(t *testing.T) {
 			},
 			expectedErr: "share version 1 requires signer of size",
 		},
+		{
+			name: "valid v2 blob",
+			proto: &v4.BlobProto{
+				NamespaceId:      namespace.ID(),
+				NamespaceVersion: uint32(namespace.Version()),
+				ShareVersion:     2,
+				Data:             makeV2Data(1, bytes.Repeat([]byte{0xAA}, FibreCommitmentSize)),
+				Signer:           bytes.Repeat([]byte{1}, SignerSize),
+			},
+			expectedErr: "",
+		},
+		{
+			name: "v2 blob with wrong data size",
+			proto: &v4.BlobProto{
+				NamespaceId:      namespace.ID(),
+				NamespaceVersion: uint32(namespace.Version()),
+				ShareVersion:     2,
+				Data:             []byte{1, 2, 3},
+				Signer:           bytes.Repeat([]byte{1}, SignerSize),
+			},
+			expectedErr: "share version 2 requires data of size",
+		},
+		{
+			name: "v2 blob missing signer",
+			proto: &v4.BlobProto{
+				NamespaceId:      namespace.ID(),
+				NamespaceVersion: uint32(namespace.Version()),
+				ShareVersion:     2,
+				Data:             makeV2Data(1, bytes.Repeat([]byte{0xAA}, FibreCommitmentSize)),
+				Signer:           nil,
+			},
+			expectedErr: "share version 2 requires signer of size",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -180,4 +219,93 @@ func TestNewBlobFromProto(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewV2Blob(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{1}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, SignerSize)
+	commitment := bytes.Repeat([]byte{0xBB}, FibreCommitmentSize)
+	fibreBlobVersion := uint32(42)
+
+	blob, err := NewV2Blob(ns, fibreBlobVersion, commitment, signer)
+	require.NoError(t, err)
+	require.Equal(t, ShareVersionTwo, blob.ShareVersion())
+	require.Equal(t, ns, blob.Namespace())
+	require.Equal(t, signer, blob.Signer())
+
+	// Verify FibreBlobVersion
+	v, err := blob.FibreBlobVersion()
+	require.NoError(t, err)
+	require.Equal(t, fibreBlobVersion, v)
+
+	// Verify FibreCommitment
+	c, err := blob.FibreCommitment()
+	require.NoError(t, err)
+	require.Equal(t, commitment, c)
+}
+
+func TestNewV2BlobInvalidCommitmentSize(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{1}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, SignerSize)
+
+	_, err := NewV2Blob(ns, 1, []byte{1, 2, 3}, signer)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "commitment must be")
+}
+
+func TestFibreBlobVersionOnNonV2Blob(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{1}, NamespaceVersionZeroIDSize))
+	blob, err := NewV0Blob(ns, []byte("data"))
+	require.NoError(t, err)
+
+	_, err = blob.FibreBlobVersion()
+	require.Error(t, err)
+
+	_, err = blob.FibreCommitment()
+	require.Error(t, err)
+}
+
+func TestV2BlobToShares(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{1}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, SignerSize)
+	commitment := bytes.Repeat([]byte{0xBB}, FibreCommitmentSize)
+
+	blob, err := NewV2Blob(ns, 1, commitment, signer)
+	require.NoError(t, err)
+
+	shares, err := blob.ToShares()
+	require.NoError(t, err)
+	require.Len(t, shares, 1) // V2 blob fits in one share
+
+	// Verify round-trip
+	blobList, err := parseSparseShares(shares)
+	require.NoError(t, err)
+	require.Len(t, blobList, 1)
+	require.Equal(t, blob.ShareVersion(), blobList[0].ShareVersion())
+	require.Equal(t, blob.Data(), blobList[0].Data())
+}
+
+func TestV2BlobProtoRoundTrip(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{1}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, SignerSize)
+	commitment := bytes.Repeat([]byte{0xBB}, FibreCommitmentSize)
+
+	blob, err := NewV2Blob(ns, 1, commitment, signer)
+	require.NoError(t, err)
+
+	// Marshal and unmarshal
+	blobBytes, err := blob.Marshal()
+	require.NoError(t, err)
+
+	newBlob, err := UnmarshalBlob(blobBytes)
+	require.NoError(t, err)
+	require.Equal(t, blob, newBlob)
+}
+
+// makeV2Data creates v2 blob data from a fibre blob version and commitment.
+func makeV2Data(fibreBlobVersion uint32, commitment []byte) []byte {
+	data := make([]byte, FibreBlobVersionSize+FibreCommitmentSize)
+	binary.BigEndian.PutUint32(data[:FibreBlobVersionSize], fibreBlobVersion)
+	copy(data[FibreBlobVersionSize:], commitment)
+	return data
 }

--- a/share/share.go
+++ b/share/share.go
@@ -85,16 +85,16 @@ func (s *Share) IsSequenceStart() bool {
 // IsCompactShare returns true if this is a compact share.
 func (s Share) IsCompactShare() bool {
 	ns := s.Namespace()
-	isCompact := ns.IsTx() || ns.IsPayForBlob()
+	isCompact := ns.IsTx() || ns.IsPayForBlob() || ns.IsPayForFibre()
 	return isCompact
 }
 
 // GetSigner returns the signer of the share, if the
-// share is not of type v1 and is not the first share in a sequence
+// share is not of type v1 or v2 and is not the first share in a sequence
 // it returns nil
 func GetSigner(share Share) []byte {
 	infoByte := share.InfoByte()
-	if infoByte.Version() != ShareVersionOne {
+	if infoByte.Version() != ShareVersionOne && infoByte.Version() != ShareVersionTwo {
 		return nil
 	}
 	if !infoByte.IsSequenceStart() {
@@ -162,8 +162,8 @@ func (s *Share) rawDataStartIndex() int {
 	if isCompact {
 		index += ShareReservedBytes
 	}
-	if s.Version() == ShareVersionOne && s.IsSequenceStart() {
-		// the first share in v1 has the signer
+	if (s.Version() == ShareVersionOne || s.Version() == ShareVersionTwo) && s.IsSequenceStart() {
+		// the first share in v1 and v2 has the signer
 		index += SignerSize
 	}
 	return index
@@ -197,7 +197,7 @@ func (s *Share) rawDataStartIndexUsingReserved() (int, error) {
 	if isStart {
 		index += SequenceLenBytes
 	}
-	if s.Version() == ShareVersionOne {
+	if s.Version() == ShareVersionOne || s.Version() == ShareVersionTwo {
 		index += SignerSize
 	}
 
@@ -232,5 +232,5 @@ func FromBytes(bytes [][]byte) (shares []Share, err error) {
 
 func (s *Share) ContainsSigner() bool {
 	infoByte := s.InfoByte()
-	return infoByte.Version() == ShareVersionOne && infoByte.IsSequenceStart()
+	return (infoByte.Version() == ShareVersionOne || infoByte.Version() == ShareVersionTwo) && infoByte.IsSequenceStart()
 }

--- a/share/share_test.go
+++ b/share/share_test.go
@@ -323,3 +323,38 @@ func shareVersionZeroWithoutSigner(t *testing.T) Share {
 	require.NoError(t, err)
 	return share
 }
+
+func TestGetSignerV2(t *testing.T) {
+	signer := bytes.Repeat([]byte{0xAA}, SignerSize)
+	s := shareVersionTwoWithSigner(t, signer)
+	got := GetSigner(s)
+	require.Equal(t, signer, got)
+}
+
+func TestIsCompactSharePayForFibre(t *testing.T) {
+	infoByte, err := NewInfoByte(ShareVersionZero, true)
+	require.NoError(t, err)
+
+	data := PayForFibreNamespace.Bytes()
+	data = append(data, byte(infoByte))
+	data = append(data, bytes.Repeat([]byte{0}, ShareSize-len(data))...)
+
+	share, err := NewShare(data)
+	require.NoError(t, err)
+	require.True(t, share.IsCompactShare())
+}
+
+func shareVersionTwoWithSigner(t *testing.T, signer []byte) Share {
+	infoByte, err := NewInfoByte(ShareVersionTwo, true)
+	require.NoError(t, err)
+
+	data := RandomBlobNamespace().Bytes()
+	data = append(data, byte(infoByte))
+	data = append(data, []byte{0, 0, 0, 0}...) // sequence len
+	data = append(data, signer...)
+	data = append(data, bytes.Repeat([]byte{0}, ShareSize-len(data))...)
+
+	share, err := NewShare(data)
+	require.NoError(t, err)
+	return share
+}

--- a/share/split_sparse_shares_test.go
+++ b/share/split_sparse_shares_test.go
@@ -2,6 +2,7 @@ package share
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,4 +59,125 @@ func TestWriteNamespacePaddingShares(t *testing.T) {
 	// verify that the padding share has the same share version as blob1
 	version := got[1].Version()
 	assert.Equal(t, version, ShareVersionZero)
+}
+
+func TestSparseShareSplitterV2Blob(t *testing.T) {
+	ns1 := MustNewV0Namespace(bytes.Repeat([]byte{1}, NamespaceVersionZeroIDSize))
+	ns2 := MustNewV0Namespace(bytes.Repeat([]byte{2}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, SignerSize)
+	commitment := bytes.Repeat([]byte{0xBB}, FibreCommitmentSize)
+	fibreBlobVersion := uint32(123)
+
+	blob1, err := NewV0Blob(ns1, []byte("data1"))
+	require.NoError(t, err)
+	blob2, err := NewV2Blob(ns2, fibreBlobVersion, commitment, signer)
+	require.NoError(t, err)
+
+	sss := NewSparseShareSplitter()
+
+	err = sss.Write(blob1)
+	assert.NoError(t, err)
+
+	err = sss.Write(blob2)
+	assert.NoError(t, err)
+
+	got := sss.Export()
+	assert.Len(t, got, 2)
+
+	// Verify share versions
+	assert.Equal(t, ShareVersionZero, got[0].Version())
+	assert.Equal(t, ShareVersionTwo, got[1].Version())
+
+	// Verify signer is present in V2 share
+	assert.Equal(t, signer, GetSigner(got[1]))
+	assert.Nil(t, GetSigner(got[0])) // V0 share should not have signer
+
+	// Parse shares back to verify round-trip
+	blobList, err := parseSparseShares(got)
+	require.NoError(t, err)
+	require.Len(t, blobList, 2)
+
+	// Verify V2 blob round-trip
+	v2Blob := blobList[1]
+	require.Equal(t, ShareVersionTwo, v2Blob.ShareVersion())
+	require.Equal(t, ns2, v2Blob.Namespace())
+	require.Equal(t, signer, v2Blob.Signer())
+
+	// Verify fibre blob version and commitment extraction
+	rv, err := v2Blob.FibreBlobVersion()
+	require.NoError(t, err)
+	require.Equal(t, fibreBlobVersion, rv)
+
+	comm, err := v2Blob.FibreCommitment()
+	require.NoError(t, err)
+	require.Equal(t, commitment, comm)
+}
+
+func TestSparseShareSplitterV2BlobSingleShare(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{3}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xCC}, SignerSize)
+	commitment := bytes.Repeat([]byte{0xDD}, FibreCommitmentSize)
+	fibreBlobVersion := uint32(456)
+
+	blob, err := NewV2Blob(ns, fibreBlobVersion, commitment, signer)
+	require.NoError(t, err)
+
+	sss := NewSparseShareSplitter()
+	err = sss.Write(blob)
+	assert.NoError(t, err)
+
+	got := sss.Export()
+	assert.Len(t, got, 1) // V2 blob should fit in a single share
+
+	// Verify share version
+	assert.Equal(t, ShareVersionTwo, got[0].Version())
+
+	// Verify sequence length is FibreBlobVersionSize + FibreCommitmentSize (36 bytes)
+	sequenceLen := got[0].SequenceLen()
+	assert.Equal(t, uint32(FibreBlobVersionSize+FibreCommitmentSize), sequenceLen)
+
+	// Verify signer is present
+	assert.Equal(t, signer, GetSigner(got[0]))
+
+	// Parse back to verify round-trip
+	blobList, err := parseSparseShares(got)
+	require.NoError(t, err)
+	require.Len(t, blobList, 1)
+
+	parsedBlob := blobList[0]
+	require.Equal(t, blob.ShareVersion(), parsedBlob.ShareVersion())
+	require.Equal(t, blob.Namespace(), parsedBlob.Namespace())
+	require.Equal(t, blob.Signer(), parsedBlob.Signer())
+
+	// Verify fibre blob version and commitment
+	rv, err := parsedBlob.FibreBlobVersion()
+	require.NoError(t, err)
+	require.Equal(t, fibreBlobVersion, rv)
+
+	comm, err := parsedBlob.FibreCommitment()
+	require.NoError(t, err)
+	require.Equal(t, commitment, comm)
+}
+
+func TestSparseShareSplitterV2BlobInvalidData(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{4}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xEE}, SignerSize)
+
+	// Create blob with wrong data size (not 36 bytes)
+	wrongData := []byte{1, 2, 3}
+
+	_, err := NewBlob(ns, wrongData, ShareVersionTwo, signer)
+	require.Error(t, err) // Should fail validation
+
+	// Test with correct data size but try to write through splitter
+	validData := make([]byte, FibreBlobVersionSize+FibreCommitmentSize)
+	binary.BigEndian.PutUint32(validData[0:FibreBlobVersionSize], uint32(789))
+	copy(validData[FibreBlobVersionSize:], bytes.Repeat([]byte{0xFF}, FibreCommitmentSize))
+
+	validBlob, err := NewBlob(ns, validData, ShareVersionTwo, signer)
+	require.NoError(t, err)
+
+	sss := NewSparseShareSplitter()
+	err = sss.Write(validBlob)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Part of #231 (splitting #223 into smaller PRs). Depends on #234.

## Summary
- Add `ShareVersionTwo` validation in `NewBlob` (requires 36-byte data + signer)
- Add `NewV2Blob()` convenience constructor for Fibre system blobs
- Add `FibreBlobVersion()` and `FibreCommitment()` methods on `Blob`
- Update `GetSigner`, `IsCompactShare`, `ContainsSigner` to handle v2
- Add `WriteFibreBlobVersion`/`WriteFibreCommitment` to share builder
- Handle v2 blob splitting in `SparseShareSplitter` (single-share layout)
- Update `isCompactShare` to include `PayForFibreNamespace`

This is PR **3 of 5**. See #231 for the full plan.

## Test plan
- [x] `go test ./...` passes
- [x] Tests for `NewV2Blob`, `FibreBlobVersion`, `FibreCommitment`
- [x] Tests for v2 blob proto round-trip
- [x] Tests for v2 sparse share splitting (single share, mixed, invalid data)
- [x] Tests for `GetSigner` with v2 shares
- [x] Tests for `IsCompactShare` with `PayForFibreNamespace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)