### PR TITLE
test: verify Fibre integration gaps and document limitations

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -359,6 +359,11 @@ func (b *Builder) Export() (Square, error) {
 
 // FindBlobStartingIndex returns the starting share index of the blob in the square. It takes
 // the index of the pfb in the tx set and the index of the blob within the PFB.
+//
+// Note: this function only supports PFB blobs. It does not support FibreTx
+// system blobs (NoPfbIndex) because their share indexes are not tracked via
+// IndexWrapper. Callers needing system blob positions can use
+// GetShareRangeForNamespace on the exported square instead.
 func (b *Builder) FindBlobStartingIndex(pfbIndex, blobIndex int) (int, error) {
 	if pfbIndex < len(b.Txs) {
 		return 0, fmt.Errorf("pfbIndex %d does not match a pfb", pfbIndex)
@@ -389,6 +394,11 @@ func (b *Builder) FindBlobStartingIndex(pfbIndex, blobIndex int) (int, error) {
 
 // BlobShareLength returns the amount of shares a blob takes up in the square. It takes
 // the index of the pfb in the tx set and the index of the blob within the PFB.
+//
+// Note: this function only supports PFB blobs. It does not support FibreTx
+// system blobs (NoPfbIndex). FibreTx system blobs always occupy exactly 1
+// share.
+//
 // TODO: we could look in to creating a map to avoid O(n) lookup when we expect large
 // numbers of blobs
 func (b *Builder) BlobShareLength(pfbIndex, blobIndex int) (int, error) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -1450,3 +1450,93 @@ func TestBuilderExportWithSystemBlobs(t *testing.T) {
 		require.NotNil(t, sq)
 	})
 }
+
+// TestBlobShareRangeNotSupportedForSystemBlobs verifies that FindBlobStartingIndex
+// and BlobShareLength return errors when called for system blobs (FibreTx blobs with
+// NoPfbIndex). System blobs are placed in the sparse share area but their share indices
+// are not recorded in any IndexWrapper, so they cannot be queried through the
+// PFB-oriented blob query interface. This is expected behavior because:
+//   - System blobs contain only metadata (fibre_blob_version + commitment)
+//   - Their inclusion can be verified through the PayForFibre tx itself
+//   - The actual Fibre data is verified off-chain against the commitment
+func TestBlobShareRangeNotSupportedForSystemBlobs(t *testing.T) {
+	ns1 := share.MustNewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
+	ns2 := share.MustNewV0Namespace(bytes.Repeat([]byte{2}, share.NamespaceVersionZeroIDSize))
+
+	builder, err := square.NewBuilder(64, 64)
+	require.NoError(t, err)
+
+	// Add a normal tx
+	builder.AppendTx([]byte("normal-tx"))
+
+	// Add a PFB tx with one blob
+	blobTx := test.GenerateBlobTxs(1, 1, 200)[0]
+	parsed, isBlobTx, err := tx.UnmarshalBlobTx(blobTx)
+	require.NoError(t, err)
+	require.True(t, isBlobTx)
+	mustAppendBlobTx(t, builder, parsed)
+
+	// Add a FibreTx with a system blob
+	fibreTx := newFibreTx(t, ns1)
+	added, err := builder.AppendFibreTx(fibreTx)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	// Add a second FibreTx with a different namespace
+	fibreTx2 := newFibreTx(t, ns2)
+	added, err = builder.AppendFibreTx(fibreTx2)
+	require.NoError(t, err)
+	require.True(t, added)
+
+	// Export the square to compute share indices
+	sq, err := builder.Export()
+	require.NoError(t, err)
+	require.NotNil(t, sq)
+
+	// Verify the builder has both PFB blobs and system blobs
+	assert.Equal(t, 1, len(builder.Txs), "should have 1 normal tx")
+	assert.Equal(t, 1, len(builder.Pfbs), "should have 1 PFB")
+	assert.Equal(t, 2, len(builder.PayForFibreTxs), "should have 2 PayForFibre txs")
+
+	// Count system blobs vs PFB blobs
+	systemBlobCount := 0
+	pfbBlobCount := 0
+	for _, blob := range builder.Blobs {
+		if blob.PfbIndex == square.NoPfbIndex {
+			systemBlobCount++
+		} else {
+			pfbBlobCount++
+		}
+	}
+	assert.Equal(t, 2, systemBlobCount, "should have 2 system blobs")
+	assert.True(t, pfbBlobCount >= 1, "should have at least 1 PFB blob")
+
+	// FindBlobStartingIndex WORKS for PFB blobs (txIndex=1 is the PFB, blobIndex=0)
+	pfbTxIndex := len(builder.Txs) // txIndex for the first PFB
+	start, err := builder.FindBlobStartingIndex(pfbTxIndex, 0)
+	assert.NoError(t, err, "FindBlobStartingIndex should work for PFB blobs")
+	assert.True(t, start > 0, "PFB blob should have a valid starting index")
+
+	// BlobShareLength WORKS for PFB blobs
+	length, err := builder.BlobShareLength(pfbTxIndex, 0)
+	assert.NoError(t, err, "BlobShareLength should work for PFB blobs")
+	assert.True(t, length > 0, "PFB blob should have a valid share length")
+
+	// FindBlobStartingIndex FAILS for FibreTx system blobs
+	// The FibreTx is at txIndex = len(Txs) + len(Pfbs) + fibreTxIdx
+	fibreTxIndex := len(builder.Txs) + len(builder.Pfbs) // first fibre tx index
+	_, err = builder.FindBlobStartingIndex(fibreTxIndex, 0)
+	assert.Error(t, err, "FindBlobStartingIndex should fail for system blob indices because they fall outside the Pfbs range")
+
+	// BlobShareLength also FAILS for system blobs via the PFB-oriented interface
+	_, err = builder.BlobShareLength(fibreTxIndex, 0)
+	assert.Error(t, err, "BlobShareLength should fail for system blob indices because they fall outside the Pfbs range")
+
+	// Verify system blobs ARE correctly placed in the square by checking
+	// the sparse share area contains shares in the system blob namespaces
+	ns1Range := share.GetShareRangeForNamespace(sq, ns1)
+	assert.False(t, ns1Range.IsEmpty(), "system blob namespace ns1 should be present in the square")
+
+	ns2Range := share.GetShareRangeForNamespace(sq, ns2)
+	assert.False(t, ns2Range.IsEmpty(), "system blob namespace ns2 should be present in the square")
+}

--- a/inclusion/commitment_test.go
+++ b/inclusion/commitment_test.go
@@ -93,12 +93,28 @@ func TestCreateCommitment(t *testing.T) {
 			shareVersion: share.ShareVersionOne,
 			signer:       bytes.Repeat([]byte{1}, share.SignerSize),
 		},
+		{
+			name:         "v2 blob (fibre system blob) of 1 share succeeds",
+			namespace:    ns1,
+			blob:         append([]byte{0, 0, 0, 1}, bytes.Repeat([]byte{0xAB}, share.FibreCommitmentSize)...),
+			expected:     []byte{0xbc, 0x9c, 0x8, 0xd4, 0x38, 0x35, 0xc0, 0x21, 0xb5, 0xd5, 0x1e, 0xca, 0xb, 0xcc, 0x89, 0x62, 0xda, 0xae, 0x3c, 0xf4, 0x6, 0xd2, 0x12, 0x98, 0x98, 0x74, 0xcc, 0x82, 0x70, 0x34, 0xc8, 0x39},
+			shareVersion: share.ShareVersionTwo,
+			signer:       bytes.Repeat([]byte{2}, share.SignerSize),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			blob, err := share.NewBlob(tt.namespace, tt.blob, tt.shareVersion, tt.signer)
 			require.NoError(t, err)
-			res, err := inclusion.CreateCommitment(blob, twoLeafMerkleRoot, defaultSubtreeRootThreshold)
+			// v2 blobs produce 1 share / 1 subtree root, so use hashConcatenatedData
+			// which works with any number of roots. v0/v1 blobs in these tests produce
+			// 2 shares / 2 subtree roots, so use twoLeafMerkleRoot for backwards
+			// compatibility with the existing expected hashes.
+			merkleRootFn := twoLeafMerkleRoot
+			if tt.shareVersion == share.ShareVersionTwo {
+				merkleRootFn = hashConcatenatedData
+			}
+			res, err := inclusion.CreateCommitment(blob, merkleRootFn, defaultSubtreeRootThreshold)
 			if tt.expectErr {
 				assert.Error(t, err)
 				return
@@ -107,6 +123,58 @@ func TestCreateCommitment(t *testing.T) {
 			assert.Equal(t, tt.expected, res)
 		})
 	}
+}
+
+// TestCreateCommitmentV2Blob verifies that CreateCommitment works correctly
+// for ShareVersionTwo (Fibre system) blobs. These blobs produce exactly 1
+// share and 1 subtree root.
+func TestCreateCommitmentV2Blob(t *testing.T) {
+	ns := share.MustNewV0Namespace(bytes.Repeat([]byte{0x1}, share.NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, share.SignerSize)
+	commitment := bytes.Repeat([]byte{0xBB}, share.FibreCommitmentSize)
+	fibreBlobVersion := uint32(1)
+
+	blob, err := share.NewV2Blob(ns, fibreBlobVersion, commitment, signer)
+	require.NoError(t, err)
+
+	// Verify v2 blob produces exactly 1 share
+	shares, err := blob.ToShares()
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(shares), "v2 blob must produce exactly 1 share")
+
+	// Verify SubTreeWidth is 1 for a single-share blob
+	subTreeWidth, err := inclusion.SubTreeWidth(1, defaultSubtreeRootThreshold)
+	require.NoError(t, err)
+	assert.Equal(t, 1, subTreeWidth)
+
+	// Verify MerkleMountainRangeSizes returns [1] for a single share
+	treeSizes, err := inclusion.MerkleMountainRangeSizes(1, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{1}, treeSizes)
+
+	// Verify GenerateSubtreeRoots produces exactly 1 root
+	roots, err := inclusion.GenerateSubtreeRoots(blob, defaultSubtreeRootThreshold)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(roots), "v2 blob must produce exactly 1 subtree root")
+	assert.NotEmpty(t, roots[0], "subtree root must not be empty")
+
+	// Verify CreateCommitment produces a deterministic, non-nil commitment
+	res, err := inclusion.CreateCommitment(blob, hashConcatenatedData, defaultSubtreeRootThreshold)
+	require.NoError(t, err)
+	assert.Len(t, res, 32, "commitment must be 32 bytes")
+
+	// Verify determinism: same blob always produces same commitment
+	res2, err := inclusion.CreateCommitment(blob, hashConcatenatedData, defaultSubtreeRootThreshold)
+	require.NoError(t, err)
+	assert.Equal(t, res, res2, "commitment must be deterministic")
+
+	// Verify parallel commitment matches sequential for v2 blobs
+	blobs := []*share.Blob{blob}
+	sequential, err := inclusion.CreateCommitments(blobs, hashConcatenatedData, defaultSubtreeRootThreshold)
+	require.NoError(t, err)
+	parallel, err := inclusion.CreateParallelCommitments(blobs, hashConcatenatedData, defaultSubtreeRootThreshold, 2)
+	require.NoError(t, err)
+	assert.Equal(t, sequential, parallel, "parallel and sequential commitments must match for v2 blobs")
 }
 
 func twoLeafMerkleRoot(data [][]byte) []byte {

--- a/square.go
+++ b/square.go
@@ -168,6 +168,11 @@ func TxShareRange(txs [][]byte, txIndex, maxSquareSize, subtreeRootThreshold int
 
 // BlobShareRange returns the range of share indexes that the blob, identified by txIndex and blobIndex, occupies.
 // The range is end exclusive.
+//
+// Note: this function only supports PFB blobs. It does not support FibreTx
+// system blobs because their share indexes are not tracked via IndexWrapper.
+// Callers needing system blob positions can use GetShareRangeForNamespace on
+// the constructed square instead.
 func BlobShareRange(txs [][]byte, txIndex, blobIndex, maxSquareSize, subtreeRootThreshold int) (share.Range, error) {
 	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold, txs...)
 	if err != nil {

--- a/square_test.go
+++ b/square_test.go
@@ -607,3 +607,54 @@ func TestWriteSquare(t *testing.T) {
 		require.Equal(t, txWriter.Count()+pfbWriter.Count(), payForFibreShareRange.Start, "PayForFibreNamespace should start after PayForBlobNamespace")
 	})
 }
+
+// TestBlobShareRangeWithPayForFibre verifies that the BlobShareRange function
+// works for PFB blobs but returns an error for FibreTx system blobs. This is
+// expected because system blobs are not tracked through the PFB IndexWrapper
+// mechanism.
+func TestBlobShareRangeWithPayForFibre(t *testing.T) {
+	ns := share.MustNewV0Namespace(bytes.Repeat([]byte{0x1}, share.NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, share.SignerSize)
+	commitment := bytes.Repeat([]byte{0xBB}, share.FibreCommitmentSize)
+	systemBlob, err := share.NewV2Blob(ns, 1, commitment, signer)
+	require.NoError(t, err)
+
+	fibreTxBytes, err := tx.MarshalFibreTx([]byte("pay-for-fibre-sdk-tx"), systemBlob)
+	require.NoError(t, err)
+
+	// Create a blob tx for testing
+	blobTxBytes := test.GenerateBlobTxs(1, 1, 200)
+
+	// Ordered txs: normal tx, blob tx, fibre tx
+	txs := [][]byte{
+		[]byte("normal-tx"),
+		blobTxBytes[0],
+		fibreTxBytes,
+	}
+
+	// TxShareRange should work for all three tx types
+	// txIndex=0: normal tx
+	txRange, err := square.TxShareRange(txs, 0, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+	assert.NoError(t, err, "TxShareRange should work for normal txs")
+	assert.False(t, txRange.IsEmpty())
+
+	// txIndex=1: blob tx (PFB)
+	txRange, err = square.TxShareRange(txs, 1, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+	assert.NoError(t, err, "TxShareRange should work for PFB txs")
+	assert.False(t, txRange.IsEmpty())
+
+	// txIndex=2: PayForFibre tx
+	txRange, err = square.TxShareRange(txs, 2, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+	assert.NoError(t, err, "TxShareRange should work for PayForFibre txs")
+	assert.False(t, txRange.IsEmpty())
+
+	// BlobShareRange should work for blob tx's blobs (txIndex=1, blobIndex=0)
+	blobRange, err := square.BlobShareRange(txs, 1, 0, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+	assert.NoError(t, err, "BlobShareRange should work for PFB blobs")
+	assert.False(t, blobRange.IsEmpty())
+
+	// BlobShareRange returns an error for FibreTx system blobs (txIndex=2, blobIndex=0)
+	// because system blobs use NoPfbIndex and are not tracked via IndexWrapper
+	_, err = square.BlobShareRange(txs, 2, 0, defaultMaxSquareSize, defaultSubtreeRootThreshold)
+	assert.Error(t, err, "BlobShareRange should return error for FibreTx system blob indices")
+}


### PR DESCRIPTION
## Summary

- Add tests verifying that `CreateCommitment` works correctly with v2 (Fibre system) blobs producing exactly 1 share and 1 subtree root
- Add tests confirming that `BlobShareRange`, `FindBlobStartingIndex`, and `BlobShareLength` correctly reject FibreTx system blobs (by design)
- Add godoc comments to `FindBlobStartingIndex`, `BlobShareLength`, and `BlobShareRange` documenting that they do not support FibreTx system blobs and directing callers to use `GetShareRangeForNamespace` instead

## Context

These tests were written to verify that go-square's Fibre support (PRs #233-#237) is feature-complete for celestia-app integration. Two potential gaps were investigated:

1. **CreateCommitment with v2 blobs** — Confirmed NOT a gap. The entire pipeline (SparseShareSplitter → SubTreeWidth → MerkleMountainRangeSizes → NMT → commitment) works correctly with v2 system blobs.
2. **BlobShareRange for system blobs** — Confirmed a gap by design. System blob share indexes are intentionally not recorded in `IndexWrapper` (NoPfbIndex). The alternative `GetShareRangeForNamespace` works correctly for locating system blobs in the constructed square.

## Test plan

- [x] `TestCreateCommitment` — v2 blob test case added
- [x] `TestCreateCommitmentV2Blob` — comprehensive v2 blob commitment verification
- [x] `TestBlobShareRangeNotSupportedForSystemBlobs` — builder-level verification
- [x] `TestBlobShareRangeWithPayForFibre` — public API verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)