### PR TITLE
chore: deprecate square.Build

### DIFF
--- a/square.go
+++ b/square.go
@@ -18,6 +18,8 @@ import (
 // in the square and which have all PFBs trailing regular transactions. Note, this function does
 // not check the underlying validity of the transactions.
 // Errors should not occur and would reflect a violation in an invariant.
+//
+// Deprecated: Use NewBuilder directly with AppendTx, AppendBlobTx, and Export instead.
 func Build(txs [][]byte, maxSquareSize, subtreeRootThreshold int) (Square, [][]byte, error) {
 	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Deprecate `square.Build` and instruct clients to use `NewBuilder` directly with `AppendTx`, `AppendBlobTx`, and `Export` instead.
- `square.Build` is not used by celestia-app's `PrepareProposal` which uses a `Builder` directly via `FilteredSquareBuilder`.

Closes https://github.com/celestiaorg/go-square/issues/206

## Test plan
- [x] Existing tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)