### PR TITLE
feat: add IsFibreBlob method to Blob type

### DIFF
--- a/share/blob.go
+++ b/share/blob.go
@@ -194,6 +194,11 @@ func (b *Blob) Data() []byte {
 	return b.data
 }
 
+// IsFibreBlob returns true if the blob is a Fibre system-level blob (share version 2).
+func (b *Blob) IsFibreBlob() bool {
+	return b.shareVersion == ShareVersionTwo
+}
+
 // FibreBlobVersion returns the Fibre blob version from a v2 blob's data.
 func (b *Blob) FibreBlobVersion() (uint32, error) {
 	if b.shareVersion != ShareVersionTwo {

--- a/share/blob_test.go
+++ b/share/blob_test.go
@@ -375,6 +375,30 @@ func TestV2BlobProtoRoundTrip(t *testing.T) {
 	require.Equal(t, blob, newBlob)
 }
 
+func TestIsFibreBlob(t *testing.T) {
+	ns := MustNewV0Namespace(bytes.Repeat([]byte{1}, NamespaceVersionZeroIDSize))
+	signer := bytes.Repeat([]byte{0xAA}, SignerSize)
+	commitment := bytes.Repeat([]byte{0xBB}, FibreCommitmentSize)
+
+	t.Run("v0 blob is not a fibre blob", func(t *testing.T) {
+		blob, err := NewV0Blob(ns, []byte("data"))
+		require.NoError(t, err)
+		assert.False(t, blob.IsFibreBlob())
+	})
+
+	t.Run("v1 blob is not a fibre blob", func(t *testing.T) {
+		blob, err := NewV1Blob(ns, []byte("data"), signer)
+		require.NoError(t, err)
+		assert.False(t, blob.IsFibreBlob())
+	})
+
+	t.Run("v2 blob is a fibre blob", func(t *testing.T) {
+		blob, err := NewV2Blob(ns, 1, commitment, signer)
+		require.NoError(t, err)
+		assert.True(t, blob.IsFibreBlob())
+	})
+}
+
 // makeV2Data creates v2 blob data from a fibre blob version and commitment.
 func makeV2Data(fibreBlobVersion uint32, commitment []byte) []byte {
 	data := make([]byte, FibreBlobVersionSize+FibreCommitmentSize)


### PR DESCRIPTION
## Summary
- Add `IsFibreBlob()` method to the `Blob` type that returns `true` for share version 2 (Fibre system-level) blobs
- Enables callers of `GetAll`/`Subscribe` to identify fibre blobs and pass the commitment to `fibre.Get` without manually parsing the share version

Ref: https://github.com/celestiaorg/celestia-node/pull/4843#discussion_r2924780701

## Test plan
- [x] Added `TestIsFibreBlob` with subtests for v0, v1, and v2 blobs
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)