### PR TITLE
chore: add Hacken bug bounty PR guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,3 +46,7 @@ Transactions/blobs → `Builder` splits into compact/sparse shares → shares as
 - **Formatting**: gofumpt (via golangci-lint), not just gofmt.
 - **Linting**: golangci-lint v2 with copyloopvar, gocritic, misspell, nakedret (max-func-lines: 0), prealloc, revive, staticcheck.
 - **Protobuf**: Generated via `buf` (dockerized). Do not edit `*.pb.go` files manually.
+
+### Security PRs
+
+- For PRs that resolve Hacken bug bounty reports, do not include details about the bug in the PR description. Instead, link to a Linear issue that contains more details on the bug and the link to the Hacken bug bounty report.


### PR DESCRIPTION
## Summary
- Add a "Security PRs" section to `CLAUDE.md`
- Instructs Claude to not include bug details in PR descriptions for Hacken bug bounty fixes; instead link to a Linear issue

Closes https://linear.app/celestia/issue/PROTOCO-1445/update-claudemd

## Test plan
- [ ] Verify `CLAUDE.md` has the new "Security PRs" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)