### PR TITLE
chore(ci): pin GitHub Actions and scope GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bufbuild/buf-setup-action@v1
-      - uses: bufbuild/buf-breaking-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
+      - uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1.1.4
         with:
           against: 'https://github.com/celestiaorg/go-square.git#branch=main'
-      - uses: bufbuild/buf-lint-action@v1
+      - uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # v1.1.1

--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -3,17 +3,23 @@ on:
   push:
     tags:
       - "v*"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: "1.44.0"
       # Push the protobuf definitions to the BSR
-      - uses: bufbuild/buf-push-action@v1
+      - uses: bufbuild/buf-push-action@a654ff18effe4641ebea4a4ce242c49800728459 # v1.2.0
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}
       - name: "push the tag label to BSR"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -14,7 +14,8 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
   pull_request:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -14,6 +14,8 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
   pull_request:
 
+permissions: {}
+
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml

--- a/.github/workflows/issue-label-automation.yml
+++ b/.github/workflows/issue-label-automation.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check if issue or PR was created by external contributor
         if: env.IS_HUMAN == 'true' && github.repository_owner == 'celestiaorg'
-        uses: tspascoal/get-user-teams-membership@v3
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
         id: teamCheck
         with:
           username: ${{ github.actor }}
@@ -26,7 +26,7 @@ jobs:
       # If an issue was unlabeled add `needs:triage`.
       - name: Maybe label issue with `needs:triage`
         if: ${{ github.event_name == 'issues' }}
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # master (repo archived)
         with:
           add-labels: "needs:triage"
           ignore-if-labeled: true
@@ -36,7 +36,7 @@ jobs:
       # celestia-core, add the `external` label.
       - name: Maybe label issue or PR with `external`
         if: env.IS_HUMAN == 'true' && steps.teamCheck.outputs.isTeamMember == 'false'
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # master (repo archived)
         with:
           add-labels: "external"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
       # If a PR was created by dependabot or mergify add the `bot` label.
       - name: Maybe label PR with `bot`
         if: env.IS_BOT == 'true'
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # master (repo archived)
         with:
           add-labels: "bot"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -15,6 +15,6 @@ jobs:
     name: conventional-commit-pr-title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,16 @@ name: lint
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
     timeout-minutes: 8
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -14,7 +19,7 @@ jobs:
         with:
           go-version-file: ./go.mod
 
-      - uses: technote-space/get-diff-action@v6.1.2
+      - uses: technote-space/get-diff-action@f27caffdd0fb9b13f4fc191c016bb4e0632844af # v6.1.2
         with:
           # This job will pass without running if go.mod, go.sum, and *.go
           # wasn't modified.
@@ -23,7 +28,7 @@ jobs:
             go.mod
             go.sum
 
-      - uses: golangci/golangci-lint-action@v9.2.0
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.3
           args: --timeout 10m
@@ -32,6 +37,8 @@ jobs:
 
   yamllint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: celestiaorg/.github/.github/actions/yamllint@v0.6.4
+      - uses: celestiaorg/.github/.github/actions/yamllint@9ee03305d3cc6cf520b7895436429aa853b58e70 # v0.6.4

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -2,9 +2,14 @@ name: markdown-linter
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,14 @@ name: test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Resolves all 20 open [CodeQL code-scanning alerts](https://github.com/celestiaorg/go-square/security/code-scanning) on `.github/workflows/*.yml`:

- **13 × `actions/unpinned-tag`** — every third-party action is now pinned to a full-length commit SHA, with the human-readable tag preserved as a trailing `# vX.Y.Z` comment.
- **7 × `actions/missing-workflow-permissions`** — every workflow/job now declares an explicit least-privilege `GITHUB_TOKEN` scope (mostly `contents: read`; `pull-requests: write` retained where a step posts to PRs; `issues: write` retained for label automation).

One commit per workflow file for easy review and bisect.

## Notes

- `andymckay/labeler` is archived; pinning to its current `master` SHA freezes supply-chain risk. Migrating off the action is tracked as a follow-up.
- `ci-release.yml` initially used `permissions: {}` (CodeQL's suggested starter), which caused a `startup_failure` because reusable workflows called from it were capped at zero permissions. Fixed in a follow-up commit to `permissions: contents: read`, which is the minimum `actions/checkout` in the callees needs and still satisfies the CodeQL rule.

Closes https://linear.app/celestia/issue/PROTOCO-1550

## Test plan

- [ ] CI (`lint`, `test`, `markdown-linter`, `buf-ci`, `ci-release`) passes
- [ ] CodeQL re-analysis on this PR marks all 20 workflow alerts as fixed