### PR TITLE
fix!: domain-separate and length-prefix Blob.Hash preimage

### DIFF
--- a/share/blob.go
+++ b/share/blob.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"sort"
 
 	v4 "github.com/celestiaorg/go-square/v4/proto/blob/v4"
@@ -159,14 +160,30 @@ func NewBlobFromProto(pb *v4.BlobProto) (*Blob, error) {
 	)
 }
 
-// Hash returns a SHA-256 hash of all the blob's fields.
+// blobHashDomain is a domain separation tag prefixed to the Hash preimage so
+// that the hash can not be confused with hashes computed over other data.
+const blobHashDomain = "celestia.blob.v1\x00"
+
+// Hash returns a SHA-256 hash of all the blob's fields. Each variable-length
+// field is length-prefixed so that distinct blobs can not be made to produce
+// the same preimage (e.g. a v0 blob whose data embeds a v1 signer).
 func (b *Blob) Hash() []byte {
 	h := sha256.New()
-	h.Write(b.Namespace().Bytes())
-	h.Write(b.Data())
+	h.Write([]byte(blobHashDomain))
+	writeLengthPrefixed(h, b.Namespace().Bytes())
+	writeLengthPrefixed(h, b.Data())
 	h.Write([]byte{b.ShareVersion()})
-	h.Write(b.Signer())
+	writeLengthPrefixed(h, b.Signer())
 	return h.Sum(nil)
+}
+
+// writeLengthPrefixed writes a 4-byte big-endian length prefix followed by the
+// data itself to h.
+func writeLengthPrefixed(h hash.Hash, data []byte) {
+	var prefix [4]byte
+	binary.BigEndian.PutUint32(prefix[:], uint32(len(data)))
+	h.Write(prefix[:])
+	h.Write(data)
 }
 
 // Namespace returns the namespace of the blob

--- a/share/blob.go
+++ b/share/blob.go
@@ -178,7 +178,9 @@ func (b *Blob) Hash() []byte {
 }
 
 // writeLengthPrefixed writes a 4-byte big-endian length prefix followed by the
-// data itself to h.
+// data itself to h. Length prefixes are used instead of separators because
+// fields contain arbitrary bytes, so any separator could also appear inside a
+// field and make the encoding ambiguous.
 func writeLengthPrefixed(h hash.Hash, data []byte) {
 	var prefix [4]byte
 	binary.BigEndian.PutUint32(prefix[:], uint32(len(data)))

--- a/share/blob_test.go
+++ b/share/blob_test.go
@@ -117,11 +117,18 @@ func TestBlobHash(t *testing.T) {
 		blob, err := NewV1Blob(ns, data, signer)
 		require.NoError(t, err)
 
+		lengthPrefixed := func(b []byte) []byte {
+			var prefix [4]byte
+			binary.BigEndian.PutUint32(prefix[:], uint32(len(b)))
+			return append(prefix[:], b...)
+		}
+
 		h := sha256.New()
-		h.Write(ns.Bytes())
-		h.Write(data)
+		h.Write([]byte(blobHashDomain))
+		h.Write(lengthPrefixed(ns.Bytes()))
+		h.Write(lengthPrefixed(data))
 		h.Write([]byte{ShareVersionOne})
-		h.Write(signer)
+		h.Write(lengthPrefixed(signer))
 		expected := h.Sum(nil)
 
 		assert.Equal(t, expected, blob.Hash())
@@ -168,6 +175,32 @@ func TestBlobHash(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.NotEqual(t, blob1.Hash(), blob2.Hash())
+	})
+
+	t.Run("cross-version collision is not possible", func(t *testing.T) {
+		// A v1 blob's signer is appended to the hash preimage without any
+		// length prefix or domain separation. Because a v0 blob has no signer
+		// (and is terminated by its version byte 0x00), an attacker can craft a
+		// v0 blob whose data embeds the v1 version byte and signer so that both
+		// preimages are byte-for-byte identical. The only prerequisite is that
+		// the victim v1 signer ends in 0x00.
+		//
+		// v1 blob: (ns, D, signer = [S0..S18, 0x00])
+		// v0 blob: (ns, D || 0x01 || S0..S18, nil)
+		victimData := []byte("victim payload")
+		victimSigner := append(bytes.Repeat([]byte{0xAA}, SignerSize-1), 0x00)
+
+		v1Blob, err := NewV1Blob(ns, victimData, victimSigner)
+		require.NoError(t, err)
+
+		attackerData := append([]byte{}, victimData...)
+		attackerData = append(attackerData, ShareVersionOne)
+		attackerData = append(attackerData, victimSigner[:SignerSize-1]...)
+		v0Blob, err := NewV0Blob(ns, attackerData)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, v1Blob.Hash(), v0Blob.Hash(),
+			"a v0 blob must not be able to collide with a v1 blob's hash")
 	})
 }
 


### PR DESCRIPTION
## Overview

Resolves the open security advisory [GHSA-jv5p-xwcc-q8mf](https://github.com/celestiaorg/go-square/security/advisories/GHSA-jv5p-xwcc-q8mf) by hardening the `Blob.Hash()` preimage construction. Details are tracked in the advisory and the Linear issue.

`Hash()` now prefixes the preimage with a domain tag and length-prefixes every variable-length field, so distinct blobs can no longer be crafted to produce the same hash.

## Testing

Added a regression test (`TestBlobHash/cross-version_collision_is_not_possible`) that fails on the old implementation and passes with the fix. Full suite and race tests pass.

## Breaking change

`Hash()` output changes for all blobs. Downstream callers that persist or key on `Hash()` output (mempool dedup, indexer caches, etc.) must re-compute it.

Closes PROTOCO-1760