### PR TITLE
fix: resolve duplicate tx body_bytes to the last occurrence

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -185,6 +185,9 @@ func (b *Builder) RevertLastBlobTx() error {
 // adds the raw SDK tx bytes to PayForFibreTxs (compact shares) and the system
 // blob to Blobs (sparse shares). It returns false if there is not enough space.
 func (b *Builder) AppendFibreTx(fibreTx *tx.FibreTx) (bool, error) {
+	if fibreTx == nil || fibreTx.SystemBlob == nil {
+		return false, errors.New("fibre tx and its system blob must be non-nil")
+	}
 	if fibreTx.SystemBlob.ShareVersion() != share.ShareVersionTwo {
 		return false, fmt.Errorf("system blobs must use ShareVersionTwo, got version %d", fibreTx.SystemBlob.ShareVersion())
 	}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1561,3 +1561,16 @@ func TestBlobShareRangeNotSupportedForSystemBlobs(t *testing.T) {
 	ns2Range := share.GetShareRangeForNamespace(sq, ns2)
 	assert.False(t, ns2Range.IsEmpty(), "system blob namespace ns2 should be present in the square")
 }
+
+// TestBuilderAppendFibreTxNil is a regression test for HackenProof
+// CELESTIA-255: AppendFibreTx dereferenced fibreTx.SystemBlob without a nil
+// guard, so passing the (nil, nil) "not a fibre tx" result of
+// tx.TryParseFibreTx panicked instead of returning an error.
+func TestBuilderAppendFibreTxNil(t *testing.T) {
+	builder, err := square.NewBuilder(64, defaultSubtreeRootThreshold)
+	require.NoError(t, err)
+
+	added, err := builder.AppendFibreTx(nil)
+	require.Error(t, err)
+	require.False(t, added)
+}

--- a/tx/pay_for_fibre.go
+++ b/tx/pay_for_fibre.go
@@ -7,6 +7,7 @@ import (
 	cosmostx "github.com/celestiaorg/go-square/v4/proto/cosmos/tx/v1beta1"
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/cosmos/btcutil/bech32"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -27,11 +28,12 @@ func TryParseFibreTx(txBytes []byte) (*FibreTx, error) {
 	if err := proto.Unmarshal(txBytes, &sdkTx); err != nil {
 		return nil, nil
 	}
-	if sdkTx.Body == nil || len(sdkTx.Body.Messages) == 0 {
+	body := resolveTxBody(txBytes, sdkTx.Body)
+	if body == nil || len(body.Messages) == 0 {
 		return nil, nil
 	}
 
-	anyMsg := sdkTx.Body.Messages[0]
+	anyMsg := body.Messages[0]
 	if anyMsg.TypeUrl != MsgPayForFibreTypeURL {
 		return nil, nil
 	}
@@ -64,6 +66,66 @@ func TryParseFibreTx(txBytes []byte) (*FibreTx, error) {
 		Tx:         txBytes,
 		SystemBlob: systemBlob,
 	}, nil
+}
+
+// resolveTxBody returns the transaction body that the Cosmos SDK's decoder reads
+// out of txBytes, which is not always the body protobuf-go produces.
+//
+// The SDK decodes these bytes as TxRaw, whose field 1 (body_bytes) is a scalar
+// bytes field, so gogoproto keeps only the last occurrence when field 1 is
+// repeated. go-square models field 1 as the singular message Tx.body, and
+// protobuf-go merges repeated occurrences of a message field, concatenating the
+// inner repeated messages. On a repeated field 1 the two therefore disagree about
+// which message comes first, and go-square must follow the SDK because the SDK is
+// what validated and signed over the transaction.
+//
+// parsed is the already-merged body from proto.Unmarshal. Every transaction a
+// standard signer produces encodes field 1 exactly once, in which case the two
+// interpretations coincide and parsed is returned untouched. A repeated field 1
+// whose last occurrence is not a valid TxBody yields nil: the SDK's decoder
+// rejects those bytes outright, so they are not a fibre tx here either.
+func resolveTxBody(txBytes []byte, parsed *cosmostx.TxBody) *cosmostx.TxBody {
+	lastBody, count := lastTopLevelField1(txBytes)
+	if count < 2 {
+		return parsed
+	}
+	var body cosmostx.TxBody
+	if err := proto.Unmarshal(lastBody, &body); err != nil {
+		return nil
+	}
+	return &body
+}
+
+// lastTopLevelField1 returns the value of the last top-level wire field 1 in
+// txBytes along with the number of times field 1 occurs. A malformed wire
+// encoding stops the scan and returns what was found so far; txBytes has already
+// been accepted by proto.Unmarshal before this is reached.
+func lastTopLevelField1(txBytes []byte) (lastBody []byte, count int) {
+	for len(txBytes) > 0 {
+		num, typ, tagLen := protowire.ConsumeTag(txBytes)
+		if tagLen < 0 {
+			return lastBody, count
+		}
+		txBytes = txBytes[tagLen:]
+
+		if num == 1 && typ == protowire.BytesType {
+			value, valueLen := protowire.ConsumeBytes(txBytes)
+			if valueLen < 0 {
+				return lastBody, count
+			}
+			lastBody = value
+			count++
+			txBytes = txBytes[valueLen:]
+			continue
+		}
+
+		valueLen := protowire.ConsumeFieldValue(num, typ, txBytes)
+		if valueLen < 0 {
+			return lastBody, count
+		}
+		txBytes = txBytes[valueLen:]
+	}
+	return lastBody, count
 }
 
 // decodeBech32Address decodes a bech32 address string (e.g. "celestia1...") and

--- a/tx/pay_for_fibre_test.go
+++ b/tx/pay_for_fibre_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/celestiaorg/go-square/v4/tx"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -232,4 +233,124 @@ func TestTryParseFibreTxMatchesManualConstruction(t *testing.T) {
 	require.Equal(t, expected.Data(), fibreTx.SystemBlob.Data())
 	require.Equal(t, expected.ShareVersion(), fibreTx.SystemBlob.ShareVersion())
 	require.Equal(t, expected.Signer(), fibreTx.SystemBlob.Signer())
+}
+
+// TestTryParseFibreTxDuplicateBodyField verifies that a repeated wire field 1
+// resolves to its last occurrence, which is the body the Cosmos SDK's TxRaw
+// decoder keeps.
+//
+// TxRaw.body_bytes is a scalar bytes field, so gogoproto discards all but the
+// last occurrence. go-square models field 1 as the singular message Tx.body, and
+// protobuf-go merges repeated occurrences of a message field, concatenating the
+// inner repeated messages. Left unhandled, the two disagree about which message
+// is first, and go-square must follow the SDK. Both orderings are covered so the
+// agreement holds in either direction.
+func TestTryParseFibreTxDuplicateBodyField(t *testing.T) {
+	ns := share.MustNewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
+	commitment := bytes.Repeat([]byte{0xFF}, share.FibreCommitmentSize)
+	signerBytes := bytes.Repeat([]byte{0xAB}, share.SignerSize)
+	signer, err := test.EncodeBech32("celestia", signerBytes)
+	require.NoError(t, err)
+
+	// A body holding a single MsgPayForFibre.
+	fibreTxBytes, err := test.BuildMsgPayForFibreTxBytes(signer, ns.Bytes(), commitment, 1)
+	require.NoError(t, err)
+	fibreBody := firstBodyField(t, fibreTxBytes)
+
+	// A body whose single message is an empty Any, so its TypeUrl is not
+	// MsgPayForFibreTypeURL.
+	otherBody, err := proto.Marshal(&cosmostx.TxBody{Messages: []*anypb.Any{{}}})
+	require.NoError(t, err)
+
+	// A repeated field 1 whose last occurrence is not a valid TxBody. The SDK's
+	// decoder rejects these outright.
+	invalidBody := []byte{0xFF}
+
+	tests := []struct {
+		name     string
+		bodies   [][]byte
+		wantNil  bool
+		wantLast []byte
+	}{
+		{
+			name:     "fibre body last",
+			bodies:   [][]byte{otherBody, fibreBody},
+			wantNil:  false,
+			wantLast: fibreBody,
+		},
+		{
+			name:     "fibre body first",
+			bodies:   [][]byte{fibreBody, otherBody},
+			wantNil:  true,
+			wantLast: otherBody,
+		},
+		{
+			name:     "duplicate fibre body",
+			bodies:   [][]byte{fibreBody, fibreBody},
+			wantNil:  false,
+			wantLast: fibreBody,
+		},
+		{
+			name:    "invalid body last",
+			bodies:  [][]byte{fibreBody, invalidBody},
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var txBytes []byte
+			for _, body := range tc.bodies {
+				txBytes = protowire.AppendBytes(protowire.AppendTag(txBytes, 1, protowire.BytesType), body)
+			}
+			// Field numbers stay non-descending, so these bytes also satisfy the
+			// SDK's ADR-027 check.
+			if tc.wantLast != nil {
+				require.Equal(t, tc.wantLast, lastBodyField(t, txBytes))
+			}
+
+			fibreTx, err := tx.TryParseFibreTx(txBytes)
+			require.NoError(t, err)
+			if tc.wantNil {
+				require.Nil(t, fibreTx)
+				return
+			}
+			require.NotNil(t, fibreTx)
+			require.Equal(t, txBytes, fibreTx.Tx)
+			require.Equal(t, ns, fibreTx.SystemBlob.Namespace())
+			require.Equal(t, signerBytes, fibreTx.SystemBlob.Signer())
+			require.Equal(t, share.ShareVersionTwo, fibreTx.SystemBlob.ShareVersion())
+		})
+	}
+}
+
+// firstBodyField returns the value of the first field 1 occurrence in txBytes.
+func firstBodyField(t *testing.T, txBytes []byte) []byte {
+	t.Helper()
+	num, typ, n := protowire.ConsumeTag(txBytes)
+	require.Equal(t, protowire.Number(1), num)
+	require.Equal(t, protowire.BytesType, typ)
+	body, m := protowire.ConsumeBytes(txBytes[n:])
+	require.Positive(t, m)
+	return body
+}
+
+// lastBodyField returns the value of the last field 1 occurrence in txBytes,
+// which is the body_bytes the Cosmos SDK's TxRaw decoder keeps.
+func lastBodyField(t *testing.T, txBytes []byte) []byte {
+	t.Helper()
+	var last []byte
+	for len(txBytes) > 0 {
+		num, typ, n := protowire.ConsumeTag(txBytes)
+		require.Positive(t, n)
+		require.Equal(t, protowire.BytesType, typ)
+		value, m := protowire.ConsumeBytes(txBytes[n:])
+		require.Positive(t, m)
+		if num == 1 {
+			last = value
+		}
+		txBytes = txBytes[n+m:]
+	}
+	require.NotNil(t, last)
+	return last
 }


### PR DESCRIPTION
## Description

`TryParseFibreTx` decided whether transaction bytes are a fibre tx by reading the body that protobuf-go produces for `cosmos.tx.v1beta1.Tx`. In that schema field 1 is the singular message `Tx.body`, and protobuf-go merges repeated occurrences of a message field, concatenating the inner `repeated` messages. The Cosmos SDK reads the same wire field as `TxRaw.body_bytes`, a scalar `bytes` field, where gogoproto keeps only the last occurrence.

So when field 1 is repeated, the two disagree about which message comes first. go-square has to follow the SDK, since the SDK is what decoded, validated and signed over the transaction.

This resolves field 1 to its last top-level occurrence before classifying. Transactions from standard signers encode field 1 exactly once, so their classification is unchanged and the added wire scan is the only cost.

Also guards `AppendFibreTx` against a nil `FibreTx` or nil system blob. It dereferenced `fibreTx.SystemBlob` on its first line, so a caller handing it the nil that `TryParseFibreTx` returns for a non-fibre tx got a panic rather than an error.

Details in PROTOCO-2288.

## Testing

- `TestTryParseFibreTxDuplicateBodyField` covers both orderings of a repeated field 1, a duplicated identical body, and a last occurrence that is not a valid `TxBody`. Both orderings fail without the change.
- `TestBuilderAppendFibreTxNil` covers the nil guard; it panics without the change.
- `go test -race ./...` passes.
