### PR TITLE
fix!: decode duplicate tx body field the way the SDK does

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -185,6 +185,9 @@ func (b *Builder) RevertLastBlobTx() error {
 // adds the raw SDK tx bytes to PayForFibreTxs (compact shares) and the system
 // blob to Blobs (sparse shares). It returns false if there is not enough space.
 func (b *Builder) AppendFibreTx(fibreTx *tx.FibreTx) (bool, error) {
+	if fibreTx == nil || fibreTx.SystemBlob == nil {
+		return false, fmt.Errorf("fibre tx and its system blob must be non-nil")
+	}
 	if fibreTx.SystemBlob.ShareVersion() != share.ShareVersionTwo {
 		return false, fmt.Errorf("system blobs must use ShareVersionTwo, got version %d", fibreTx.SystemBlob.ShareVersion())
 	}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1561,3 +1561,16 @@ func TestBlobShareRangeNotSupportedForSystemBlobs(t *testing.T) {
 	ns2Range := share.GetShareRangeForNamespace(sq, ns2)
 	assert.False(t, ns2Range.IsEmpty(), "system blob namespace ns2 should be present in the square")
 }
+
+// TestBuilderAppendFibreTxNil asserts AppendFibreTx reports an error rather than
+// panicking when handed a nil fibre tx.
+func TestBuilderAppendFibreTxNil(t *testing.T) {
+	builder, err := square.NewBuilder(8, 64)
+	require.NoError(t, err)
+
+	added, err := builder.AppendFibreTx(nil)
+	require.Error(t, err)
+	require.False(t, added)
+	require.Empty(t, builder.PayForFibreTxs)
+	require.Empty(t, builder.Blobs)
+}

--- a/tx/pay_for_fibre.go
+++ b/tx/pay_for_fibre.go
@@ -7,6 +7,7 @@ import (
 	cosmostx "github.com/celestiaorg/go-square/v4/proto/cosmos/tx/v1beta1"
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/cosmos/btcutil/bech32"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -27,11 +28,15 @@ func TryParseFibreTx(txBytes []byte) (*FibreTx, error) {
 	if err := proto.Unmarshal(txBytes, &sdkTx); err != nil {
 		return nil, nil
 	}
-	if sdkTx.Body == nil || len(sdkTx.Body.Messages) == 0 {
+	body, err := authoritativeBody(txBytes, &sdkTx)
+	if err != nil {
+		return nil, nil
+	}
+	if body == nil || len(body.Messages) == 0 {
 		return nil, nil
 	}
 
-	anyMsg := sdkTx.Body.Messages[0]
+	anyMsg := body.Messages[0]
 	if anyMsg.TypeUrl != MsgPayForFibreTypeURL {
 		return nil, nil
 	}
@@ -64,6 +69,63 @@ func TryParseFibreTx(txBytes []byte) (*FibreTx, error) {
 		Tx:         txBytes,
 		SystemBlob: systemBlob,
 	}, nil
+}
+
+// txBodyFieldNumber is the wire field number of the body field in
+// cosmos.tx.v1beta1.Tx, and of body_bytes in cosmos.tx.v1beta1.TxRaw. Both
+// describe the same wire field of the same transaction bytes.
+const txBodyFieldNumber = protowire.Number(1)
+
+// authoritativeBody returns the TxBody that the Cosmos SDK would decode from
+// txBytes.
+//
+// This package models the body field as a singular message, so protobuf-go
+// merges every occurrence of it and concatenates the repeated `messages` inside.
+// The SDK models the same wire field as TxRaw.body_bytes, a scalar `bytes`
+// field, so it keeps only the last occurrence. For bytes carrying the field more
+// than once the two disagree about which messages the transaction contains, and
+// a classifier that disagrees with the SDK about a transaction it shares is a
+// consensus hazard. Follow the SDK: the last occurrence wins.
+//
+// merged is the already-unmarshalled Tx and is returned as-is in the ordinary
+// single-occurrence case, so honest transactions decode exactly as before.
+func authoritativeBody(txBytes []byte, merged *cosmostx.Tx) (*cosmostx.TxBody, error) {
+	var last []byte
+	seen := 0
+	for rest := txBytes; len(rest) > 0; {
+		num, typ, n := protowire.ConsumeTag(rest)
+		if n < 0 {
+			return nil, protowire.ParseError(n)
+		}
+		rest = rest[n:]
+
+		if num == txBodyFieldNumber && typ == protowire.BytesType {
+			value, m := protowire.ConsumeBytes(rest)
+			if m < 0 {
+				return nil, protowire.ParseError(m)
+			}
+			last = value
+			seen++
+			rest = rest[m:]
+			continue
+		}
+
+		m := protowire.ConsumeFieldValue(num, typ, rest)
+		if m < 0 {
+			return nil, protowire.ParseError(m)
+		}
+		rest = rest[m:]
+	}
+
+	if seen <= 1 {
+		return merged.Body, nil
+	}
+
+	var body cosmostx.TxBody
+	if err := proto.Unmarshal(last, &body); err != nil {
+		return nil, err
+	}
+	return &body, nil
 }
 
 // decodeBech32Address decodes a bech32 address string (e.g. "celestia1...") and

--- a/tx/pay_for_fibre_test.go
+++ b/tx/pay_for_fibre_test.go
@@ -306,6 +306,15 @@ func TestTryParseFibreTxDuplicateBody(t *testing.T) {
 			bodies:    [][]byte{fibreBody, fibreBody, normalBody},
 			wantFibre: false,
 		},
+		{
+			// protobuf-go cannot merge a body that is not valid wire format, so
+			// these bytes are rejected before the last-occurrence rule is reached.
+			// The SDK's decoder rejects them too, since body_bytes must parse as a
+			// TxBody, so the two still agree on this input.
+			name:      "trailing body that is not a valid TxBody is not a fibre tx",
+			bodies:    [][]byte{fibreBody, {0xFF}},
+			wantFibre: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/tx/pay_for_fibre_test.go
+++ b/tx/pay_for_fibre_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/celestiaorg/go-square/v4/tx"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -232,4 +233,98 @@ func TestTryParseFibreTxMatchesManualConstruction(t *testing.T) {
 	require.Equal(t, expected.Data(), fibreTx.SystemBlob.Data())
 	require.Equal(t, expected.ShareVersion(), fibreTx.SystemBlob.ShareVersion())
 	require.Equal(t, expected.Signer(), fibreTx.SystemBlob.Signer())
+}
+
+// appendBodyField appends a top-level field 1 (body) carrying body to txBytes.
+func appendBodyField(txBytes, body []byte) []byte {
+	out := append([]byte(nil), txBytes...)
+	out = protowire.AppendTag(out, 1, protowire.BytesType)
+	return protowire.AppendBytes(out, body)
+}
+
+// bodyOf returns the single top-level field 1 value of a marshalled Tx.
+func bodyOf(t *testing.T, txBytes []byte) []byte {
+	t.Helper()
+	num, typ, n := protowire.ConsumeTag(txBytes)
+	require.GreaterOrEqual(t, n, 0)
+	require.Equal(t, protowire.Number(1), num)
+	require.Equal(t, protowire.BytesType, typ)
+	body, m := protowire.ConsumeBytes(txBytes[n:])
+	require.GreaterOrEqual(t, m, 0)
+	require.Len(t, txBytes, n+m, "expected exactly one top-level field")
+	return body
+}
+
+// TestTryParseFibreTxDuplicateBody pins the semantics of a Tx carrying more than
+// one top-level body field. protobuf-go merges repeated occurrences of a
+// singular message field, whereas the Cosmos SDK reads the same wire field as a
+// scalar `bytes` (TxRaw.body_bytes) and keeps only the last occurrence. The two
+// must agree on which body is authoritative, so TryParseFibreTx follows the
+// SDK's last-one-wins rule.
+func TestTryParseFibreTxDuplicateBody(t *testing.T) {
+	ns := share.MustNewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
+	commitment := bytes.Repeat([]byte{0xFF}, share.FibreCommitmentSize)
+	signerBytes := bytes.Repeat([]byte{0xAB}, share.SignerSize)
+	signer, err := test.EncodeBech32("celestia", signerBytes)
+	require.NoError(t, err)
+
+	fibreTxBytes, err := test.BuildMsgPayForFibreTxBytes(signer, ns.Bytes(), commitment, 1)
+	require.NoError(t, err)
+	fibreBody := bodyOf(t, fibreTxBytes)
+
+	normalTxBytes, err := proto.Marshal(&cosmostx.Tx{
+		Body: &cosmostx.TxBody{
+			Messages: []*anypb.Any{{TypeUrl: "/cosmos.bank.v1beta1.MsgSend", Value: []byte("v")}},
+		},
+	})
+	require.NoError(t, err)
+	normalBody := bodyOf(t, normalTxBytes)
+
+	tests := []struct {
+		name string
+		// bodies are appended in order; the last one is authoritative.
+		bodies    [][]byte
+		wantFibre bool
+	}{
+		{
+			name:      "fibre body then normal body is not a fibre tx",
+			bodies:    [][]byte{fibreBody, normalBody},
+			wantFibre: false,
+		},
+		{
+			name:      "normal body then fibre body is a fibre tx",
+			bodies:    [][]byte{normalBody, fibreBody},
+			wantFibre: true,
+		},
+		{
+			name:      "trailing fibre body wins over several normal bodies",
+			bodies:    [][]byte{normalBody, normalBody, fibreBody},
+			wantFibre: true,
+		},
+		{
+			name:      "trailing normal body wins over several fibre bodies",
+			bodies:    [][]byte{fibreBody, fibreBody, normalBody},
+			wantFibre: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var txBytes []byte
+			for _, body := range tc.bodies {
+				txBytes = appendBodyField(txBytes, body)
+			}
+
+			fibreTx, err := tx.TryParseFibreTx(txBytes)
+			require.NoError(t, err)
+			if !tc.wantFibre {
+				require.Nil(t, fibreTx)
+				return
+			}
+			require.NotNil(t, fibreTx)
+			require.Equal(t, txBytes, fibreTx.Tx)
+			require.Equal(t, ns, fibreTx.SystemBlob.Namespace())
+			require.Equal(t, signerBytes, fibreTx.SystemBlob.Signer())
+		})
+	}
 }


### PR DESCRIPTION
I plan on releasing this and backporting it to celestia-app v9.x.

Decode the transaction body field the way the Cosmos SDK does. The SDK reads that wire field as `TxRaw.body_bytes`, a scalar `bytes`, and keeps the last occurrence; protobuf-go merges every occurrence of a singular message field. go-square now follows the SDK.

Transactions carrying the field exactly once — every transaction a standard signer produces — decode exactly as before. Also guards `AppendFibreTx` against a nil fibre tx or system blob.

Note for reviewers: breaking, because it changes the square produced for transactions that carry the field more than once.

Details: https://linear.app/celestia/issue/PROTOCO-2288