### PR TITLE
chore: preallocate slices flagged by prealloc

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -370,7 +370,7 @@ func TestBuilderFindTxShareRangeWithPayForFibre(t *testing.T) {
 }
 
 func rawData(shares []share.Share) ([]byte, error) {
-	var data []byte
+	data := make([]byte, 0, len(shares)*share.ShareSize)
 	for _, share := range shares {
 		data = append(data, share.RawData()...)
 	}

--- a/inclusion/commitment.go
+++ b/inclusion/commitment.go
@@ -68,7 +68,7 @@ func GenerateSubtreeRoots(blob *sh.Blob, subtreeRootThreshold int) ([][]byte, er
 			// the namespace in the share, and therefore the parity data, while
 			// also allowing for the manual addition of the parity namespace to
 			// the parity data.
-			nsLeaf := make([]byte, 0)
+			nsLeaf := make([]byte, 0, len(namespace.Bytes())+len(leaf))
 			nsLeaf = append(nsLeaf, namespace.Bytes()...)
 			nsLeaf = append(nsLeaf, leaf...)
 

--- a/inclusion/commitment_test.go
+++ b/inclusion/commitment_test.go
@@ -188,7 +188,7 @@ func twoLeafMerkleRoot(data [][]byte) []byte {
 }
 
 func hashConcatenatedData(data [][]byte) []byte {
-	var total []byte
+	total := make([]byte, 0, len(data)*len(data[0]))
 	for _, d := range data {
 		total = append(total, d...)
 	}

--- a/square.go
+++ b/square.go
@@ -243,7 +243,7 @@ func (s Square) IsEmpty() bool {
 // ToBytes returns all the shares in the square flattened into a single byte
 // slice.
 func (s Square) ToBytes() []byte {
-	result := []byte{}
+	result := make([]byte, 0, len(s)*share.ShareSize)
 	for _, share := range s {
 		result = append(result, share.ToBytes()...)
 	}


### PR DESCRIPTION
Preallocates four slices flagged by golangci-lint's prealloc linter (newer golangci-lint versions fail `make lint` locally on these). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiYCXpgTgPVA84xeEqe5Lf