### PR TITLE
fix: return error from AppendFibreTx on nil fibre tx or system blob

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -185,6 +185,12 @@ func (b *Builder) RevertLastBlobTx() error {
 // adds the raw SDK tx bytes to PayForFibreTxs (compact shares) and the system
 // blob to Blobs (sparse shares). It returns false if there is not enough space.
 func (b *Builder) AppendFibreTx(fibreTx *tx.FibreTx) (bool, error) {
+	if fibreTx == nil {
+		return false, errors.New("fibre tx must not be nil")
+	}
+	if fibreTx.SystemBlob == nil {
+		return false, errors.New("fibre tx must have a system blob")
+	}
 	if fibreTx.SystemBlob.ShareVersion() != share.ShareVersionTwo {
 		return false, fmt.Errorf("system blobs must use ShareVersionTwo, got version %d", fibreTx.SystemBlob.ShareVersion())
 	}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1047,6 +1047,19 @@ func TestBuilderAppendFibreTx(t *testing.T) {
 	require.Len(t, builder.Blobs, 2)
 }
 
+func TestBuilderAppendFibreTxNilGuards(t *testing.T) {
+	builder, err := square.NewBuilder(8, 64)
+	require.NoError(t, err)
+
+	added, err := builder.AppendFibreTx(nil)
+	require.ErrorContains(t, err, "nil")
+	require.False(t, added)
+
+	added, err = builder.AppendFibreTx(&tx.FibreTx{Tx: []byte("raw tx")})
+	require.ErrorContains(t, err, "system blob")
+	require.False(t, added)
+}
+
 func TestBuilderRevertPayForFibreTx(t *testing.T) {
 	ns1 := share.MustNewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
 


### PR DESCRIPTION
AppendFibreTx dereferenced its argument before any nil check, so a caller passing a nil FibreTx or one without a system blob panicked instead of getting an error. Found while reviewing #277; restores the guard from the closed #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiYCXpgTgPVA84xeEqe5Lf