### PR TITLE
fix: validate tx ordering in TxShareRange and BlobShareRange

### DIFF
--- a/square.go
+++ b/square.go
@@ -158,6 +158,10 @@ func populateBuilder(builder *Builder, txs [][]byte) error {
 // TxShareRange returns the range of share indexes that the tx, specified by txIndex, occupies.
 // The range is end exclusive.
 func TxShareRange(txs [][]byte, txIndex, maxSquareSize, subtreeRootThreshold int) (share.Range, error) {
+	if err := validateTxOrdering(txs); err != nil {
+		return share.Range{}, err
+	}
+
 	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold, txs...)
 	if err != nil {
 		return share.Range{}, err
@@ -174,6 +178,10 @@ func TxShareRange(txs [][]byte, txIndex, maxSquareSize, subtreeRootThreshold int
 // Callers needing system blob positions can use GetShareRangeForNamespace on
 // the constructed square instead.
 func BlobShareRange(txs [][]byte, txIndex, blobIndex, maxSquareSize, subtreeRootThreshold int) (share.Range, error) {
+	if err := validateTxOrdering(txs); err != nil {
+		return share.Range{}, err
+	}
+
 	builder, err := NewBuilder(maxSquareSize, subtreeRootThreshold, txs...)
 	if err != nil {
 		return share.Range{}, err

--- a/square_test.go
+++ b/square_test.go
@@ -320,6 +320,18 @@ func TestSquareTxShareRange(t *testing.T) {
 	}
 }
 
+func TestShareRangeRejectsMisorderedTxs(t *testing.T) {
+	blobTxs, err := test.GenerateBlobTxs(1, 1, 100)
+	require.NoError(t, err)
+	txs := [][]byte{blobTxs[0], newTx(100)}
+
+	_, err = square.TxShareRange(txs, 0, 128, 64)
+	require.ErrorContains(t, err, "cannot be appended after blob tx")
+
+	_, err = square.BlobShareRange(txs, 0, 0, 128, 64)
+	require.ErrorContains(t, err, "cannot be appended after blob tx")
+}
+
 func TestSquareTxShareRangeWithPayForFibre(t *testing.T) {
 	ns := share.MustNewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
 	normalTx := newTx(100)


### PR DESCRIPTION
TxShareRange and BlobShareRange interpret txIndex against the normal → PFB → pay-for-fibre share layout, so a misordered tx list silently returned the share range of the wrong transaction. They now run the same ordering validation as Construct and return an error instead. Found while reviewing #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiYCXpgTgPVA84xeEqe5Lf