### PR TITLE
refactor!: reject unknown fields and nested blobs

### DIFF
--- a/tx/blob_tx.go
+++ b/tx/blob_tx.go
@@ -15,6 +15,13 @@ const (
 	ProtoBlobTxTypeID = "BLOB"
 )
 
+var (
+	// ErrNonCanonicalBlobTx indicates that a BlobTx contains unrecognized fields.
+	ErrNonCanonicalBlobTx = errors.New("non-canonical BlobTx encoding")
+	// ErrNestedBlobTx indicates that a BlobTx contains another BlobTx.
+	ErrNestedBlobTx = errors.New("nested BlobTx wrapper")
+)
+
 type BlobTx struct {
 	Tx    []byte
 	Blobs []*share.Blob
@@ -32,11 +39,20 @@ func UnmarshalBlobTx(tx []byte) (*BlobTx, bool, error) {
 	if bTx.TypeId != ProtoBlobTxTypeID {
 		return nil, false, errors.New("invalid type id")
 	}
+	if len(bTx.ProtoReflect().GetUnknown()) != 0 {
+		return nil, true, ErrNonCanonicalBlobTx
+	}
 	if len(bTx.Blobs) == 0 {
 		return nil, true, errors.New("no blobs provided")
 	}
+	if hasBlobTxTypeID(bTx.Tx) {
+		return nil, true, ErrNestedBlobTx
+	}
 	blobs := make([]*share.Blob, len(bTx.Blobs))
 	for i, b := range bTx.Blobs {
+		if len(b.ProtoReflect().GetUnknown()) != 0 {
+			return nil, true, fmt.Errorf("%w: blob %d", ErrNonCanonicalBlobTx, i)
+		}
 		blobs[i], err = share.NewBlobFromProto(b)
 		if err != nil {
 			return nil, true, err
@@ -46,6 +62,11 @@ func UnmarshalBlobTx(tx []byte) (*BlobTx, bool, error) {
 		Tx:    bTx.Tx,
 		Blobs: blobs,
 	}, true, nil
+}
+
+func hasBlobTxTypeID(txBytes []byte) bool {
+	var blobTx v4.BlobTx
+	return proto.Unmarshal(txBytes, &blobTx) == nil && blobTx.TypeId == ProtoBlobTxTypeID
 }
 
 // MarshalBlobTx creates a BlobTx using a normal transaction and some number of

--- a/tx/blob_tx_test.go
+++ b/tx/blob_tx_test.go
@@ -1,0 +1,88 @@
+package tx_test
+
+import (
+	"testing"
+
+	v4 "github.com/celestiaorg/go-square/v4/proto/blob/v4"
+	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/celestiaorg/go-square/v4/tx"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestUnmarshalBlobTxRejectsUnrecognizedFields(t *testing.T) {
+	clean := cleanBlobTx(t)
+
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, []byte) []byte
+	}{
+		{
+			name: "known field with wrong wire type",
+			mutate: func(_ *testing.T, blobTx []byte) []byte {
+				return append(blobTx, 0x10, 0x33)
+			},
+		},
+		{
+			name: "unknown wrapper field",
+			mutate: func(_ *testing.T, blobTx []byte) []byte {
+				return append(blobTx, 0x78, 0x01)
+			},
+		},
+		{
+			name: "unknown blob field",
+			mutate: func(t *testing.T, blobTx []byte) []byte {
+				var wrapper v4.BlobTx
+				require.NoError(t, proto.Unmarshal(blobTx, &wrapper))
+				wrapper.Blobs[0].ProtoReflect().SetUnknown([]byte{0x78, 0x01})
+				encoded, err := proto.Marshal(&wrapper)
+				require.NoError(t, err)
+				return encoded
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blobTx, isBlobTx, err := tx.UnmarshalBlobTx(tt.mutate(t, append([]byte(nil), clean...)))
+
+			require.ErrorIs(t, err, tx.ErrNonCanonicalBlobTx)
+			require.True(t, isBlobTx)
+			require.Nil(t, blobTx)
+		})
+	}
+}
+
+func TestUnmarshalBlobTxRejectsNestedWrapper(t *testing.T) {
+	inner := cleanBlobTx(t)
+	blob := newBlob(t)
+	outer, err := tx.MarshalBlobTx(inner, blob)
+	require.NoError(t, err)
+
+	blobTx, isBlobTx, err := tx.UnmarshalBlobTx(outer)
+
+	require.ErrorIs(t, err, tx.ErrNestedBlobTx)
+	require.True(t, isBlobTx)
+	require.Nil(t, blobTx)
+}
+
+func cleanBlobTx(t *testing.T) []byte {
+	t.Helper()
+
+	blobTx, err := tx.MarshalBlobTx([]byte("inner tx"), newBlob(t))
+	require.NoError(t, err)
+	return blobTx
+}
+
+func newBlob(t *testing.T) *share.Blob {
+	t.Helper()
+
+	blob, err := share.NewBlob(
+		share.RandomBlobNamespace(),
+		[]byte("blob data"),
+		share.ShareVersionZero,
+		nil,
+	)
+	require.NoError(t, err)
+	return blob
+}


### PR DESCRIPTION
## Overview

Moved this to go-square since that’s where BlobTxs are decoded. It keeps validation in one place, avoids decoding large blob txs twice in the app, and makes every caller follow the same rules.

I get if we want to enforce this on app level though so open to feedback.

Fixes https://linear.app/celestia/issue/PROTOCO-2363/handle-celestia-265-14-power-proposer-gets-honest-full-nodes-to-commit